### PR TITLE
fix(core): prevent prototype pollution in mergeStandardHeaders

### DIFF
--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -42,16 +42,52 @@ it('getFilenameFromContentDisposition', () => {
   expect(getFilenameFromContentDisposition('inline; filename*=!%40%23%24%25^%25^%26%2A%28%29%27%22.txt; size=123')).toEqual('!@#$%^%^&*()\'".txt')
 })
 
-it('mergeStandardHeaders', () => {
-  expect(mergeStandardHeaders({ a: '1' }, { a: '2' })).toEqual({ a: ['1', '2'] })
-  expect(mergeStandardHeaders({ a: ['1'] }, { a: '2' })).toEqual({ a: ['1', '2'] })
-  expect(mergeStandardHeaders({ a: ['1', '2'] }, { a: '3' })).toEqual({ a: ['1', '2', '3'] })
-  expect(mergeStandardHeaders({ a: ['1', '2'] }, { a: ['3'] })).toEqual({ a: ['1', '2', '3'] })
-  expect(mergeStandardHeaders({ a: ['1', '2'] }, { a: ['3', '4'] })).toEqual({ a: ['1', '2', '3', '4'] })
+describe('mergeStandardHeaders', () => {
+  afterEach(() => {
+    expect(({} as any).polluted).toEqual(undefined)
+    expect(({} as any).a).toEqual(undefined)
+  })
 
-  expect(mergeStandardHeaders({ a: '1' }, { b: '2' })).toEqual({ a: '1', b: '2' })
-  expect(mergeStandardHeaders({ a: '1', b: undefined }, { b: '2' })).toEqual({ a: '1', b: '2' })
-  expect(mergeStandardHeaders({ a: '1' }, { a: undefined, b: '2' })).toEqual({ a: '1', b: '2' })
+  it('merge duplicated keys', () => {
+    expect(mergeStandardHeaders({ a: '1' }, { a: '2' })).toEqual({ a: ['1', '2'] })
+    expect(mergeStandardHeaders({ a: ['1'] }, { a: '2' })).toEqual({ a: ['1', '2'] })
+    expect(mergeStandardHeaders({ a: ['1', '2'] }, { a: '3' })).toEqual({ a: ['1', '2', '3'] })
+    expect(mergeStandardHeaders({ a: ['1', '2'] }, { a: ['3'] })).toEqual({ a: ['1', '2', '3'] })
+    expect(mergeStandardHeaders({ a: ['1', '2'] }, { a: ['3', '4'] })).toEqual({ a: ['1', '2', '3', '4'] })
+  })
+
+  it('handle distinct and undefined keys', () => {
+    expect(mergeStandardHeaders({ a: '1' }, { b: '2' })).toEqual({ a: '1', b: '2' })
+    expect(mergeStandardHeaders({ a: '1', b: undefined }, { b: '2' })).toEqual({ a: '1', b: '2' })
+    expect(mergeStandardHeaders({ a: '1' }, { a: undefined, b: '2' })).toEqual({ a: '1', b: '2' })
+
+    // an unset marker coming only from b is carried through, like `headers['content-type'] = undefined`
+    expect(Object.keys(mergeStandardHeaders({ a: '1' }, { b: undefined }))).toEqual(['a', 'b'])
+  })
+
+  it('keep keys of a in position, then keys only in b', () => {
+    expect(Object.keys(mergeStandardHeaders({ c: '1', a: '2' }, { b: '3', a: '4' }))).toEqual(['c', 'a', 'b'])
+  })
+
+  it('not pollute the prototype through __proto__ in b', () => {
+    const b = JSON.parse('{ "__proto__": { "polluted": "yes" } }')
+
+    const merged = mergeStandardHeaders({ a: '1' }, b)
+
+    expect(Object.getPrototypeOf(merged)).toEqual(Object.prototype)
+    expect(Object.getOwnPropertyDescriptor(merged, '__proto__')?.value).toEqual({ polluted: 'yes' })
+    expect(merged.a).toEqual('1')
+  })
+
+  it('not pollute the prototype through __proto__ in both a and b', () => {
+    const a = JSON.parse('{ "__proto__": "1" }')
+    const b = JSON.parse('{ "__proto__": "2" }')
+
+    const merged = mergeStandardHeaders(a, b)
+
+    expect(Object.getPrototypeOf(merged)).toEqual(Object.prototype)
+    expect(Object.getOwnPropertyDescriptor(merged, '__proto__')?.value).toEqual(['1', '2'])
+  })
 })
 
 it('flattenStandardHeader', () => {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -38,23 +38,19 @@ export function flattenStandardHeader(header: string | readonly string[] | undef
 }
 
 export function mergeStandardHeaders(a: StandardHeaders, b: StandardHeaders): StandardHeaders {
-  const merged = { ...a }
+  const merged = { ...a, ...b }
 
   for (const key in b) {
-    if (Array.isArray(b[key])) {
-      merged[key] = [...toArray(merged[key]), ...b[key]]
+    if (!Object.hasOwn(a, key)) {
+      continue
     }
-    else if (b[key] !== undefined) {
-      if (Array.isArray(merged[key])) {
-        merged[key] = [...merged[key], b[key]]
-      }
-      else if (merged[key] !== undefined) {
-        merged[key] = [merged[key], b[key]]
-      }
-      else {
-        merged[key] = b[key]
-      }
-    }
+
+    const aValue = a[key]
+    const bValue = b[key]
+
+    merged[key] = aValue === undefined || bValue === undefined
+      ? aValue ?? bValue
+      : [...toArray(aValue), ...toArray(bValue)]
   }
 
   return merged


### PR DESCRIPTION
`mergeStandardHeaders` could be made to corrupt objects it never owned. Merging a headers object that carries a `__proto__` key — which `JSON.parse` produces from untrusted input, and which is a valid HTTP token name — replaced the prototype of the merged result instead of storing a header. With an object value, that pollution reaches every plain object in the process.

Two smaller holes came with it: keys inherited from the source object were merged in as if they were real headers, and members of `Object.prototype` (`constructor`, `toString`, …) were mistaken for existing header values, producing merged results that were never sent by either side.

## Results

- Untrusted headers can no longer touch the prototype chain. A `__proto__` header is now kept as an ordinary header value, so nothing is silently dropped either.
- Only real, own headers are merged — inherited properties and `Object.prototype` members no longer leak into the output.
- Merge behaviour is otherwise unchanged: same values, same key order, same handling of `undefined` unset markers.

## Verification

Seven cases in `packages/core/src/utils.test.ts` cover the merge semantics and each injection vector, with an `afterEach` asserting the global prototype stayed clean. Three of them fail against the previous implementation. Full suite green (772 tests), types and lint clean.

## Not included

`toStandardHeaders` in `packages/fetch/src/headers.ts` has the same bug class: a repeated `__proto__` header corrupts the accumulator and both values disappear. It is contained to that one object rather than the global prototype, so it is left for a separate PR.
