### PR TITLE
fix(peer): harden request lifecycle and improve hot-path performance

### DIFF
--- a/packages/peer/src/client.test.ts
+++ b/packages/peer/src/client.test.ts
@@ -162,6 +162,31 @@ describe('clientPeer', () => {
       await expect(response.resolveBody()).rejects.toThrow()
     })
 
+    it('resolves when the response arrives while the request message is still being sent', async () => {
+      send.mockImplementation(async (message) => {
+        if (message.kind === 'request') {
+          // simulate a transport that delivers and processes the message before send resolves
+          await peer.message(makeResponseMessage(message.id, 'early'))
+        }
+      })
+
+      const response = await peer.request(makeRequest())
+      expect(response.status).toBe(200)
+      expect(await response.resolveBody()).toBe('early')
+    })
+
+    it('does not send the request when the peer is closed while encoding the body', async () => {
+      const form = new FormData()
+      form.append('note', 'hello')
+
+      const promise = peer.request(makeRequest({ body: form }))
+      const closePromise = peer.close()
+
+      await expect(promise).rejects.toThrow(AbortError)
+      await closePromise
+      expect(send).not.toHaveBeenCalled()
+    })
+
     it('rethrow and auto close if throw during toStandardBody', async () => {
       const error = new Error('something went wrong')
       toStandardBodySpy.mockImplementationOnce(() => {
@@ -205,6 +230,19 @@ describe('clientPeer', () => {
       expect(send).toHaveBeenNthCalledWith(2, { id, kind: 'cancel' })
     })
 
+    it('throws when signal aborted during encode', async () => {
+      const controller = new AbortController()
+      const form = new FormData()
+      form.append('note', 'hello')
+
+      const promise = peer.request(makeRequest({ body: form, signal: controller.signal }))
+      controller.abort(new Error('aborted during encode'))
+
+      await expect(promise).rejects.toThrow('aborted during encode')
+      // the request message is never sent, only the cancel
+      expect(send.mock.calls.map(([m]) => m.kind)).toEqual(['cancel'])
+    })
+
     it('throws when signal aborted during send', async () => {
       const controller = new AbortController()
       send.mockImplementation(async () => {
@@ -230,6 +268,71 @@ describe('clientPeer', () => {
       const { id, promise } = await requestAndGetId()
       await peer.message(makeCancelMessage(id))
       await expect(promise).rejects.toThrow(AbortError)
+    })
+
+    it('removes the abort listener once the response is finished', async () => {
+      const controller = new AbortController()
+      const addSpy = vi.spyOn(controller.signal, 'addEventListener')
+      const removeSpy = vi.spyOn(controller.signal, 'removeEventListener')
+
+      const { id, promise } = await requestAndGetId(makeRequest({ signal: controller.signal }))
+      expect(addSpy).toHaveBeenCalledTimes(1)
+      expect(removeSpy).not.toHaveBeenCalled()
+
+      await peer.message(makeResponseMessage(id, 'done'))
+      await promise
+
+      // the exact listener that was added is removed again
+      expect(removeSpy).toHaveBeenCalledTimes(1)
+      expect(removeSpy).toHaveBeenCalledWith('abort', addSpy.mock.calls[0]![1])
+
+      // aborting after completion is a no-op: no cancel message is sent
+      controller.abort(new Error('late abort'))
+      await sleep(1)
+      expect(send.mock.calls.map(([m]) => m.kind)).toEqual(['request'])
+    })
+
+    it('keeps the abort listener while the response streams and removes it when the stream finishes', async () => {
+      const controller = new AbortController()
+      const removeSpy = vi.spyOn(controller.signal, 'removeEventListener')
+
+      const { id, promise } = await requestAndGetId(makeRequest({ signal: controller.signal }))
+      await peer.message(makeStreamingResponse(id, 'event-stream'))
+
+      const response = await promise
+      const iter = await response.resolveBody() as AsyncIterator<unknown>
+
+      // the response is not finished yet, so aborting must still be possible
+      expect(removeSpy).not.toHaveBeenCalled()
+
+      await peer.message(makeEventStreamMessage(id, 'bye', 'close'))
+      await expect(iter.next()).resolves.toEqual({ value: 'bye', done: true })
+
+      expect(removeSpy).toHaveBeenCalledTimes(1)
+
+      // aborting after completion is a no-op: no cancel message is sent
+      controller.abort(new Error('late abort'))
+      await sleep(1)
+      expect(send.mock.calls.map(([m]) => m.kind)).toEqual(['request'])
+    })
+
+    it('silently ignores transport failures when sending the cancel message on abort', async () => {
+      send.mockImplementation(async (message) => {
+        if (message.kind === 'cancel') {
+          throw new Error('transport down')
+        }
+      })
+
+      const controller = new AbortController()
+      const promise = peer.request(makeRequest({ signal: controller.signal }))
+      await waitForSend()
+
+      const reason = new Error('user abort')
+      controller.abort(reason)
+
+      await expect(promise).rejects.toBe(reason)
+      // let the failed cancel delivery settle; it must not surface anywhere
+      await sleep(1)
     })
   })
 
@@ -290,6 +393,61 @@ describe('clientPeer', () => {
 
         await peer.message(makeResponseMessage(id))
         await promise
+      })
+
+      it('stops transmitting the event-stream request body when a full response arrives', async () => {
+        const iter = makeHangingIter()
+        const returnSpy = vi.spyOn(iter, 'return')
+
+        const { id, promise } = await requestAndGetId(
+          makeRequest({ method: 'POST', headers: {}, body: iter }),
+        )
+
+        await peer.message(makeResponseMessage(id, 'done'))
+        const response = await promise
+        expect(await response.resolveBody()).toBe('done')
+
+        // the server no longer reads the request body, so the upload is cancelled locally
+        expect(returnSpy).toHaveBeenCalled()
+        expect(send.mock.calls.map(([m]) => m.kind)).toEqual(['request'])
+      })
+
+      it('releases the event-stream request body when the request completes during send', async () => {
+        const iter = makeHangingIter()
+        const returnSpy = vi.spyOn(iter, 'return')
+
+        send.mockImplementation(async (message) => {
+          if (message.kind === 'request') {
+            await peer.message(makeResponseMessage(message.id, 'done'))
+          }
+        })
+
+        const response = await peer.request(makeRequest({ method: 'POST', headers: {}, body: iter }))
+        expect(await response.resolveBody()).toBe('done')
+
+        // the body is released in the background, after the response already settled
+        await vi.waitFor(() => expect(returnSpy).toHaveBeenCalled())
+        expect(send.mock.calls.map(([m]) => m.kind)).toEqual(['request'])
+      })
+
+      it('silently ignores transport failures when aborting after an event-stream body error', async () => {
+        const iteratorError = new Error('iterator broke')
+        const iter = new AsyncIteratorClass<unknown>(async () => {
+          throw iteratorError
+        }, async () => {})
+
+        send.mockImplementation(async (message) => {
+          if (message.kind === 'cancel') {
+            throw new Error('transport down')
+          }
+        })
+
+        await expect(
+          peer.request(makeRequest({ method: 'POST', headers: {}, body: iter })),
+        ).rejects.toBe(iteratorError)
+
+        // let the failed cancel delivery settle; it must not surface anywhere
+        await sleep(1)
       })
 
       it('does not send cancel message on non-protocol error if request was resolved', async () => {
@@ -441,6 +599,63 @@ describe('clientPeer', () => {
 
         await peer.message(makeResponseMessage(id))
         await promise
+      })
+
+      it('stops transmitting the octet-stream request body when a full response arrives', async () => {
+        const cancel = vi.fn()
+        const stream = new ReadableStream<Uint8Array>({ start() { /* hangs */ }, cancel })
+
+        const { id, promise } = await requestAndGetId(
+          makeRequest({ method: 'POST', headers: {}, body: stream }),
+        )
+
+        await peer.message(makeResponseMessage(id, 'done'))
+        const response = await promise
+        expect(await response.resolveBody()).toBe('done')
+
+        // the server no longer reads the request body, so the upload is cancelled locally
+        expect(cancel).toHaveBeenCalled()
+        expect(send.mock.calls.map(([m]) => m.kind)).toEqual(['request'])
+      })
+
+      it('releases the octet-stream request body when the request completes during send', async () => {
+        const cancel = vi.fn()
+        const stream = new ReadableStream<Uint8Array>({ start() { /* hangs */ }, cancel })
+
+        send.mockImplementation(async (message) => {
+          if (message.kind === 'request') {
+            await peer.message(makeResponseMessage(message.id, 'done'))
+          }
+        })
+
+        const response = await peer.request(makeRequest({ method: 'POST', headers: {}, body: stream }))
+        expect(await response.resolveBody()).toBe('done')
+
+        // the body is released in the background, after the response already settled
+        await vi.waitFor(() => expect(cancel).toHaveBeenCalled())
+        expect(send.mock.calls.map(([m]) => m.kind)).toEqual(['request'])
+      })
+
+      it('silently ignores transport failures when aborting after an octet-stream body error', async () => {
+        const streamError = new Error('stream broke')
+        const stream = new ReadableStream<Uint8Array<ArrayBuffer>>({
+          pull(controller) {
+            controller.error(streamError)
+          },
+        })
+
+        send.mockImplementation(async (message) => {
+          if (message.kind === 'cancel') {
+            throw new Error('transport down')
+          }
+        })
+
+        await expect(
+          peer.request(makeRequest({ method: 'POST', headers: {}, body: stream })),
+        ).rejects.toBe(streamError)
+
+        // let the failed cancel delivery settle; it must not surface anywhere
+        await sleep(1)
       })
 
       it('does not send cancel message on error if request was resolved', async () => {

--- a/packages/peer/src/client.ts
+++ b/packages/peer/src/client.ts
@@ -1,7 +1,7 @@
 import type { StandardLazyResponse, StandardRequest } from '@standardserver/core'
 import type { Queue } from '@standardserver/shared'
 import type { ClientPeerSendMessage, PeerEventStreamMessage, PeerOctetStreamMessage, ServerPeerSendMessage } from './types'
-import { AbortError, isAsyncIteratorObject, SequentialIdGenerator } from '@standardserver/shared'
+import { AbortError, hasAnyDefinedValue, isAsyncIteratorObject, SequentialIdGenerator } from '@standardserver/shared'
 import { encodeAtomicStandardBody, toStandardBody } from './body'
 import { EventStreamTransmitter } from './event-stream'
 import { OctetStreamTransmitter } from './octet-stream'
@@ -13,7 +13,7 @@ interface ClientPeerRequestStateInternal {
   octetStreamMessageQueue?: Queue<PeerOctetStreamMessage> | undefined
   eventStreamTransmitter?: EventStreamTransmitter | undefined
   octetStreamTransmitter?: OctetStreamTransmitter | undefined
-  cleanupFns?: (() => void)[] | undefined
+  removeAbortListener?: (() => void) | undefined
 }
 
 export class ClientPeer {
@@ -28,32 +28,49 @@ export class ClientPeer {
   /**
    * Send a request to the server peer
    */
-  async request(request: StandardRequest): Promise<StandardLazyResponse> {
-    const signal = request.signal
-    signal?.throwIfAborted()
+  request(request: StandardRequest): Promise<StandardLazyResponse> {
+    return new Promise<StandardLazyResponse>((resolve, reject) => {
+      const signal = request.signal
+      signal?.throwIfAborted()
 
-    const id = this.idGenerator.generate()
-    const state: ClientPeerRequestStateInternal = {}
-    this.requests.set(id, state)
+      const id = this.idGenerator.generate()
+      const state: ClientPeerRequestStateInternal = { resolve, reject }
+      this.requests.set(id, state)
 
-    let abortListener: () => Promise<void>
-    signal?.addEventListener('abort', abortListener = () => this.abortById(id, signal.reason))
-    /**
-     * Make sure to remove the abort listener when the request/response is closed.
-     * Since a signal can be reused for multiple requests, if each request
-     * adds listeners without removing them, it can lead to excessive memory usage
-     * until the signal is garbage collected.
-     */
-    state.cleanupFns ??= []
-    state.cleanupFns.push(() => {
-      signal?.removeEventListener('abort', abortListener)
+      if (signal) {
+        const abortListener = () => {
+          // a failed cancel delivery must not surface as an unhandled rejection
+          void this.abortById(id, signal.reason).catch(() => {})
+        }
+        signal.addEventListener('abort', abortListener)
+        /**
+         * Make sure to remove the abort listener when the request/response is closed.
+         * Since a signal can be reused for multiple requests, if each request
+         * adds listeners without removing them, it can lead to excessive memory usage
+         * until the signal is garbage collected.
+         */
+        state.removeAbortListener = () => signal.removeEventListener('abort', abortListener)
+      }
+
+      void this.transmitRequest(id, state, request)
     })
+  }
 
+  private async transmitRequest(
+    id: string,
+    state: ClientPeerRequestStateInternal,
+    request: StandardRequest,
+  ): Promise<void> {
     try {
       const encodedAtomicBody = await encodeAtomicStandardBody(request.body, request.headers)
 
       // signal can be aborted during encode
-      signal?.throwIfAborted()
+      request.signal?.throwIfAborted()
+
+      // the peer can be closed during encode
+      if (this.requests.get(id) !== state) {
+        return
+      }
 
       // PeerRequestMessage must be sent before stream messages
       await this.send({
@@ -62,53 +79,48 @@ export class ClientPeer {
         json: {
           method: request.method === 'POST' ? undefined : request.method,
           url: request.url,
-          headers: Object.entries(encodedAtomicBody.headers).every(([,v]) => v === undefined) ? undefined : encodedAtomicBody.headers,
+          headers: hasAnyDefinedValue(encodedAtomicBody.headers) ? encodedAtomicBody.headers : undefined,
           body: encodedAtomicBody.jsonBody,
         },
         binary: encodedAtomicBody.binary,
       })
 
-      // signal can be aborted after sending request message
-      signal?.throwIfAborted()
-
       if (isAsyncIteratorObject(request.body)) {
         const transmitter = new EventStreamTransmitter(request.body, id, this.send)
-        state.eventStreamTransmitter = transmitter
 
-        // Do not await here; we don't want it to block response processing.
-        void transmitter.transmit().catch(async (error) => {
-          // only abort if stream transmitter is still active
-          if (state.eventStreamTransmitter) {
-            await this.abortById(id, error)
-          }
-
-          // WARNING: errors that occur here are silently ignored.
-        })
+        // The request can already be settled/cancelled while was in flight
+        if (this.requests.get(id) !== state) {
+          await transmitter.cancel()
+        }
+        else {
+          state.eventStreamTransmitter = transmitter
+          await transmitter.transmit().catch((error) => {
+            if (state.eventStreamTransmitter) {
+              return this.abortById(id, error)
+            }
+          })
+        }
       }
       else if (request.body instanceof ReadableStream) {
         const transmitter = new OctetStreamTransmitter(request.body, id, this.send)
-        state.octetStreamTransmitter = transmitter
 
-        // Do not await here; we don't want it to block response processing.
-        void transmitter.transmit().catch(async (error) => {
-          // only abort if stream transmitter is still active
-          if (state.octetStreamTransmitter) {
-            await this.abortById(id, error)
-          }
-
-          // WARNING: errors that occur here are silently ignored.
-        })
+        // The request can already be settled/cancelled while was in flight
+        if (this.requests.get(id) !== state) {
+          await transmitter.cancel()
+        }
+        else {
+          state.octetStreamTransmitter = transmitter
+          await transmitter.transmit().catch((error) => {
+            if (state.octetStreamTransmitter) {
+              return this.abortById(id, error)
+            }
+          })
+        }
       }
     }
     catch (reason) {
       await this.closeById(id, reason)
-      throw reason
     }
-
-    return new Promise((resolve, reject) => {
-      state.resolve = resolve
-      state.reject = reject
-    })
   }
 
   /**
@@ -175,6 +187,7 @@ export class ClientPeer {
         status: message.json.status ?? 200,
         resolveBody: decoded.resolveBody,
       })
+      state.reject = undefined
 
       if (!state.eventStreamMessageQueue && !state.octetStreamMessageQueue) {
         // if there is no stream, we can close the request immediately
@@ -202,7 +215,11 @@ export class ClientPeer {
     }
 
     this.requests.delete(id)
-    reason ??= new AbortError('Request was closed')
+
+    // avoid allocating an error (and its stack trace) when nothing observes the reason
+    if (state.reject || state.eventStreamMessageQueue || state.octetStreamMessageQueue) {
+      reason ??= new AbortError('Request was closed')
+    }
 
     state.reject?.(reason)
     state.resolve = undefined
@@ -220,13 +237,13 @@ export class ClientPeer {
     state.eventStreamTransmitter = undefined
     state.octetStreamTransmitter = undefined
 
-    state.cleanupFns?.forEach(fn => fn())
-    state.cleanupFns = undefined
+    state.removeAbortListener?.()
+    state.removeAbortListener = undefined
 
     await Promise.all(promises)
   }
 
-  private async abortById(id: string, reason?: unknown): Promise<void> {
+  private async abortById(id: string, reason: unknown): Promise<void> {
     const state = this.requests.get(id)
 
     if (!state) { // already closed
@@ -253,8 +270,8 @@ export class ClientPeer {
     state.eventStreamTransmitter = undefined
     state.octetStreamTransmitter = undefined
 
-    state.cleanupFns?.forEach(fn => fn())
-    state.cleanupFns = undefined
+    state.removeAbortListener?.()
+    state.removeAbortListener = undefined
 
     await Promise.all(promises)
   }

--- a/packages/peer/src/codec.ts
+++ b/packages/peer/src/codec.ts
@@ -36,11 +36,12 @@ export async function encodePeerMessage(
   message: PeerMessage,
   options: EncodePeerMessageOptions = {},
 ): Promise<string | Uint8Array<ArrayBuffer>> {
-  const jsonPart = stringifyJSON({ ...message, binary: undefined })
-
   if (message.binary === undefined) {
+    const jsonPart = stringifyJSON(message)
     return options.prefix ? options.prefix + jsonPart : jsonPart
   }
+
+  const jsonPart = stringifyJSON({ ...message, binary: undefined })
 
   const textBytes = textEncoder.encode(
     options.prefix ? options.prefix + jsonPart : jsonPart,

--- a/packages/peer/src/server.test.ts
+++ b/packages/peer/src/server.test.ts
@@ -271,6 +271,29 @@ describe('serverPeer', () => {
       it('ignores event-stream for non-existing request', async () => {
         await peer.message(makeEventStreamMessage('nonexist', 'ignored'), vi.fn())
       })
+
+      it('stops accepting event-stream messages once the body is fully consumed', async () => {
+        const { handler, box } = deferredHandler()
+        const msg = makeRequestMessage({ headers: { 'standard-server': 'event-stream' } })
+        const promise = peer.message(msg, handler)
+
+        await vi.waitFor(() => expect(handler).toHaveBeenCalled())
+        const request = handler.mock.calls[0]![0]
+        const iter = await request.resolveBody() as AsyncIterator<unknown>
+
+        await peer.message(makeEventStreamMessage('1', 'bye', 'close'), vi.fn())
+        await expect(iter.next()).resolves.toEqual({ value: 'bye', done: true })
+
+        // late messages are ignored instead of buffered forever
+        await peer.message(makeEventStreamMessage('1', 'late'), vi.fn())
+        expect((peer as any).requests.get('1').eventStreamMessageQueue).toBeUndefined()
+
+        box.resolve(jsonResponse())
+        await promise
+
+        // the fully consumed body does not trigger a stream/cancel on close
+        expect(send.mock.calls.map(([m]) => m.kind)).toEqual(['response'])
+      })
     })
 
     describe('response body (outgoing)', () => {

--- a/packages/peer/src/server.ts
+++ b/packages/peer/src/server.ts
@@ -1,7 +1,7 @@
 import type { StandardLazyRequest, StandardResponse } from '@standardserver/core'
 import type { Queue } from '@standardserver/shared'
 import type { ClientPeerSendMessage, PeerEventStreamMessage, PeerOctetStreamMessage, PeerResponseMessage, ServerPeerSendMessage } from './types'
-import { AbortError, isAsyncIteratorObject } from '@standardserver/shared'
+import { AbortError, hasAnyDefinedValue, isAsyncIteratorObject } from '@standardserver/shared'
 import { encodeAtomicStandardBody, toStandardBody } from './body'
 import { EventStreamTransmitter } from './event-stream'
 import { HibernationAsyncIteratorClass } from './hibernation'
@@ -58,10 +58,17 @@ export class ServerPeer {
 
     try {
       const decoded = toStandardBody(message, async ({ kind }) => {
-        if (kind === 'cancelled' && (state.eventStreamMessageQueue || state.octetStreamMessageQueue)) {
+        /**
+         * The request body is finished (fully read, errored, or cancelled).
+         * Drop the queues so late stream messages are ignored instead of
+         * buffered forever.
+         */
+        const streamActive = state.eventStreamMessageQueue !== undefined || state.octetStreamMessageQueue !== undefined
+        state.eventStreamMessageQueue = undefined
+        state.octetStreamMessageQueue = undefined
+
+        if (kind === 'cancelled' && streamActive) {
           // only need cancel stream if streams is still active
-          state.eventStreamMessageQueue = undefined
-          state.octetStreamMessageQueue = undefined
           await this.send({ id, kind: 'stream/cancel' })
         }
       })
@@ -89,11 +96,11 @@ export class ServerPeer {
       }
 
       const responseMessage: PeerResponseMessage = {
-        id: message.id,
+        id,
         kind: 'response',
         json: {
           status: response.status === 200 ? undefined : response.status,
-          headers: Object.entries(encodedAtomicBody.headers).every(([,v]) => v === undefined) ? undefined : encodedAtomicBody.headers,
+          headers: hasAnyDefinedValue(encodedAtomicBody.headers) ? encodedAtomicBody.headers : undefined,
           body: encodedAtomicBody.jsonBody,
         },
         binary: encodedAtomicBody.binary,
@@ -109,15 +116,15 @@ export class ServerPeer {
 
       if (isAsyncIteratorObject(response.body)) {
         if (response.body instanceof HibernationAsyncIteratorClass) {
-          await response.body['~callback']?.(message.id)
+          await response.body['~callback']?.(id)
         }
         else {
-          const transmitter = new EventStreamTransmitter(response.body, message.id, this.send)
+          const transmitter = new EventStreamTransmitter(response.body, id, this.send)
           state.eventStreamTransmitter = transmitter
           await transmitter.transmit().catch(async (reason) => {
             // only cancel if stream transmitter is still active
             if (state.eventStreamTransmitter) {
-              await this.cancelById(message.id, reason)
+              await this.cancelById(id, reason)
             }
 
             // WARNING: errors that occur here are silently ignored.
@@ -125,12 +132,12 @@ export class ServerPeer {
         }
       }
       else if (response.body instanceof ReadableStream) {
-        const transmitter = new OctetStreamTransmitter(response.body, message.id, this.send)
+        const transmitter = new OctetStreamTransmitter(response.body, id, this.send)
         state.octetStreamTransmitter = transmitter
         await transmitter.transmit().catch(async (reason) => {
           // only cancel if stream transmitter is still active
           if (state.octetStreamTransmitter) {
-            await this.cancelById(message.id, reason)
+            await this.cancelById(id, reason)
           }
 
           // WARNING: errors that occur here are silently ignored.
@@ -142,7 +149,7 @@ export class ServerPeer {
       await this.closeById(id)
     }
     catch (reason) {
-      await this.cancelById(message.id, reason)
+      await this.cancelById(id, reason)
       throw reason
     }
   }
@@ -163,7 +170,10 @@ export class ServerPeer {
     }
 
     this.requests.delete(id)
-    reason ??= new AbortError('Request was closed')
+
+    if (state.controller || state.eventStreamMessageQueue || state.octetStreamMessageQueue) {
+      reason ??= new AbortError('Request was closed')
+    }
 
     state.controller?.abort(reason)
     state.controller = undefined

--- a/packages/peer/tests/peer.test.ts
+++ b/packages/peer/tests/peer.test.ts
@@ -52,6 +52,39 @@ describe('peer integration (client <-> server over encoded wire)', () => {
     expect(await response.resolveBody()).toEqual({ echo: { name: 'Alice' }, url: '/greet', method: 'PUT' })
   })
 
+  it('completes when the transport waits for full remote processing before send resolves', async () => {
+    const prefix = 'peer:'
+    const wire = {} as { client: ClientPeer, server: ServerPeer }
+
+    const handler = async (request: StandardLazyRequest): Promise<StandardResponse> => ({
+      status: 200,
+      headers: {},
+      body: { pong: request.url },
+    })
+
+    // unlike `connect()`, each send awaits the remote side handling the message,
+    // so the response arrives while the request `send` is still in flight
+    wire.client = new ClientPeerClass(async (message) => {
+      const decoded = decodePeerMessage(await encodePeerMessage(message, { prefix }), { prefix })
+      if (!decoded.matched) {
+        throw new Error('Failed to decode message on the wire')
+      }
+      await wire.server.message(decoded.message as ClientPeerSendMessage, handler)
+    })
+
+    wire.server = new ServerPeerClass(async (message) => {
+      const decoded = decodePeerMessage(await encodePeerMessage(message, { prefix }), { prefix })
+      if (!decoded.matched) {
+        throw new Error('Failed to decode message on the wire')
+      }
+      await wire.client.message(decoded.message as ServerPeerSendMessage)
+    })
+
+    const response = await wire.client.request({ url: '/ping', method: 'GET', headers: {} })
+    expect(response.status).toBe(200)
+    expect(await response.resolveBody()).toEqual({ pong: '/ping' })
+  })
+
   it('handles multiple concurrent requests over the same connection', async () => {
     const { client } = connect(async request => ({
       status: 200,

--- a/packages/shared/src/object.test.ts
+++ b/packages/shared/src/object.test.ts
@@ -1,4 +1,12 @@
-import { isTypescriptObject } from './object'
+import { hasAnyDefinedValue, isTypescriptObject } from './object'
+
+it('hasAnyDefinedValue', () => {
+  expect(hasAnyDefinedValue({})).toBe(false)
+  expect(hasAnyDefinedValue({ 'content-type': undefined, 'standard-server': undefined })).toBe(false)
+
+  expect(hasAnyDefinedValue({ 'content-type': undefined, 'x-custom': 'yes' })).toBe(true)
+  expect(hasAnyDefinedValue({ 'set-cookie': ['a=1'] })).toBe(true)
+})
 
 it('isTypescriptObject', () => {
   expect(isTypescriptObject(null)).toBe(false)

--- a/packages/shared/src/object.ts
+++ b/packages/shared/src/object.ts
@@ -1,4 +1,19 @@
 /**
+ * Checks whether the object has at least one property with a defined value.
+ * Keys holding `undefined` are treated as absent, matching JSON semantics
+ * where such entries disappear on serialization.
+ */
+export function hasAnyDefinedValue(object: Record<string, unknown>): boolean {
+  for (const key in object) {
+    if (object[key] !== undefined) {
+      return true
+    }
+  }
+
+  return false
+}
+
+/**
  * Checks whether the provided container is a typescript object (object or function).
  */
 export function isTypescriptObject(maybeObject: unknown): maybeObject is object & Record<PropertyKey, unknown> {


### PR DESCRIPTION
This PR fixes several request-lifecycle bugs in `@standardserver/peer` and trims allocations from its hot paths. Most importantly, a response arriving while the request message is still being sent is no longer dropped — previously this deadlocked requests forever on synchronous/in-memory transports. It also simplifies the protocol: the server no longer sends `stream/cancel` on normal completion, since the client stops its own upload once the full response arrives.

**Fixes**
- Responses delivered while `send()` is still in flight resolve normally instead of hanging the request (in-memory, MessagePort-style, or ACK-awaiting transports).
- A request that settles mid-send releases its unread streaming body instead of uploading to a server that no longer reads it.
- Transport failures while delivering `cancel` no longer surface as unhandled promise rejections.
- Abort listeners are removed exactly when a request finishes — including streaming responses — so reused signals don't accumulate listeners.
- The server ignores late stream messages once a request body finished, instead of buffering them without bound.

**Protocol**
- No `stream/cancel` on normal completion; the client stops its own upload when the full response arrives (pinned by tests). It is still sent when a running handler stops reading the body early.

**Performance**
- No Error/stack-capture allocation on the happy path of plain requests.
- Fewer allocations per message: early-exit header check (new `hasAnyDefinedValue` in `@standardserver/shared`), no object spread when encoding binary-less messages, one abort-cleanup field per request instead of an array.

**Testing**
- New unit and integration regression tests, all verified to fail (deadlocks, unhandled rejections) against the previous implementation.
- Peer package coverage stays at 100%; full repo suite, eslint, and `tsc -b` are green.