### PR TITLE
fix(node): read response errors from the underlying http2 stream

### DIFF
--- a/packages/node/src/response.ts
+++ b/packages/node/src/response.ts
@@ -2,7 +2,7 @@ import type { StandardResponse } from '@standardserver/core'
 import type { ToNodeHttpBodyOptions } from './body'
 import type { NodeHttpResponse } from './types'
 import { toNodeHttpBody } from './body'
-import { canWriteToNodeResponse } from './utils'
+import { canWriteToNodeResponse, getNodeResponseError } from './utils'
 
 export interface SendStandardResponseOptions extends ToNodeHttpBodyOptions {
 }
@@ -16,13 +16,15 @@ export async function sendStandardResponse(
 
   return new Promise((resolve, reject) => {
     if (!canWriteToNodeResponse(res)) {
+      const error = getNodeResponseError(res)
+
       if (typeof resBody === 'object' && !resBody.closed) {
         resBody.on('error', reject)
-        resBody.destroy(res.errored ?? undefined)
+        resBody.destroy(error ?? undefined)
       }
 
-      if (res.errored) {
-        reject(res.errored)
+      if (error) {
+        reject(error)
       }
       else {
         resolve()
@@ -54,7 +56,7 @@ export async function sendStandardResponse(
     else {
       res.once('close', () => {
         if (!resBody.closed) {
-          resBody.destroy(res.errored ?? undefined)
+          resBody.destroy(getNodeResponseError(res) ?? undefined)
         }
       })
 

--- a/packages/node/src/signal.test.ts
+++ b/packages/node/src/signal.test.ts
@@ -133,4 +133,42 @@ describe('toAbortSignal', async () => {
 
     await handled
   })
+
+  it('on http2 response with underlying stream already errored', async ({ onTestFinished }) => {
+    const server = http2.createServer()
+    onTestFinished(() => new Promise<any>(r => server.close(r)))
+
+    const error = new Error('test')
+
+    const handled = new Promise<void>((resolve, reject) => {
+      server.on('request', async (req, res) => {
+        try {
+          // catch error
+          res.stream.once('error', () => {})
+          res.stream.destroy(error)
+
+          await new Promise<void>(r => res.stream.once('close', () => r()))
+
+          const signal = toAbortSignal(res)
+
+          expect(signal.aborted).toBe(true)
+          expect(signal.reason).toBe(error)
+
+          resolve()
+        }
+        catch (error) {
+          reject(error)
+        }
+      })
+    })
+
+    await new Promise<void>(r => server.listen(0, r))
+    const port = (server.address() as any).port
+
+    const client = http2.connect(`http://localhost:${port}`)
+    const reqStream = client.request({ ':path': '/' })
+    reqStream.once('error', () => client.close())
+
+    await handled
+  })
 })

--- a/packages/node/src/signal.ts
+++ b/packages/node/src/signal.ts
@@ -1,13 +1,15 @@
 import type Stream from 'node:stream'
 import type { NodeHttpResponse } from './types'
 import { AbortError } from '@standardserver/shared'
-import { canWriteToNodeResponse } from './utils'
+import { canWriteToNodeResponse, getNodeResponseError } from './utils'
 
 export function toAbortSignal(stream: Stream.Writable | NodeHttpResponse): AbortSignal {
   const controller = new AbortController()
 
-  if (stream.errored) {
-    controller.abort(stream.errored)
+  const error = getNodeResponseError(stream)
+
+  if (error) {
+    controller.abort(error)
   }
   else if (!canWriteToNodeResponse(stream)) {
     if (!stream.writableFinished || !stream.writableEnded) {

--- a/packages/node/src/utils.test.ts
+++ b/packages/node/src/utils.test.ts
@@ -1,7 +1,7 @@
 import http from 'node:http'
 import http2 from 'node:http2'
 import { connect } from 'node:net'
-import { canWriteToNodeResponse } from './utils'
+import { canWriteToNodeResponse, getNodeResponseError } from './utils'
 
 describe('canWriteToNodeResponse', () => {
   it('on http1 response aborted by client', async ({ onTestFinished }) => {
@@ -120,6 +120,146 @@ describe('canWriteToNodeResponse', () => {
           await vi.waitFor(() => {
             expect(canWriteToNodeResponse(res)).toBe(false)
           })
+
+          resolve()
+        }
+        catch (error) {
+          reject(error)
+        }
+      })
+    })
+
+    await new Promise<void>(r => server.listen(0, r))
+    const port = (server.address() as any).port
+
+    const client = http2.connect(`http://localhost:${port}`)
+    const reqStream = client.request({ ':path': '/' })
+    reqStream.on('data', () => {})
+    reqStream.once('end', () => client.close())
+
+    await handled
+  })
+})
+
+describe('getNodeResponseError', () => {
+  it('on http1 response destroyed with an error', async ({ onTestFinished }) => {
+    const server = http.createServer()
+    onTestFinished(() => new Promise<any>(r => server.close(r)))
+
+    const error = new Error('test')
+
+    const handled = new Promise<void>((resolve, reject) => {
+      server.on('request', async (req, res) => {
+        try {
+          expect(getNodeResponseError(res)).toBe(null)
+
+          // catch error
+          res.once('error', () => {})
+          res.destroy(error)
+
+          await new Promise<void>(r => res.once('close', () => r()))
+
+          expect(getNodeResponseError(res)).toBe(error)
+
+          resolve()
+        }
+        catch (error) {
+          reject(error)
+        }
+      })
+    })
+
+    await new Promise<void>(r => server.listen(0, r))
+    const port = (server.address() as any).port
+
+    http.get(`http://localhost:${port}`, res => res.resume()).once('error', () => {})
+
+    await handled
+  })
+
+  it('on http1 response finished normally', async ({ onTestFinished }) => {
+    const server = http.createServer()
+    onTestFinished(() => new Promise<any>(r => server.close(r)))
+
+    const handled = new Promise<void>((resolve, reject) => {
+      server.on('request', async (req, res) => {
+        try {
+          res.end('ok')
+
+          await new Promise<void>(r => res.once('close', () => r()))
+
+          expect(getNodeResponseError(res)).toBe(null)
+
+          resolve()
+        }
+        catch (error) {
+          reject(error)
+        }
+      })
+    })
+
+    await new Promise<void>(r => server.listen(0, r))
+    const port = (server.address() as any).port
+
+    http.get(`http://localhost:${port}`, res => res.resume())
+
+    await handled
+  })
+
+  it('on http2 response destroyed with an error', async ({ onTestFinished }) => {
+    const server = http2.createServer()
+    onTestFinished(() => new Promise<any>(r => server.close(r)))
+
+    const error = new Error('test')
+
+    const handled = new Promise<void>((resolve, reject) => {
+      server.on('request', async (req, res) => {
+        try {
+          expect(getNodeResponseError(res)).toBe(null)
+
+          // catch error
+          res.stream.once('error', () => {})
+          res.stream.destroy(error)
+
+          await new Promise<void>(r => res.stream.once('close', () => r()))
+
+          expect(getNodeResponseError(res)).toBe(error)
+
+          // `Http2ServerResponse` extends `Stream`, not `Writable`, so the error is only
+          // reachable through the underlying `Http2Stream` - reading it off the response
+          // itself silently yields `undefined`, despite what `@types/node` declares
+          expect((res as any).errored).toBe(undefined)
+
+          resolve()
+        }
+        catch (error) {
+          reject(error)
+        }
+      })
+    })
+
+    await new Promise<void>(r => server.listen(0, r))
+    const port = (server.address() as any).port
+
+    const client = http2.connect(`http://localhost:${port}`)
+    const reqStream = client.request({ ':path': '/' })
+    reqStream.once('error', () => client.close())
+
+    await handled
+  })
+
+  it('on http2 response finished normally', async ({ onTestFinished }) => {
+    const server = http2.createServer()
+    onTestFinished(() => new Promise<any>(r => server.close(r)))
+
+    const handled = new Promise<void>((resolve, reject) => {
+      server.on('request', async (req, res) => {
+        try {
+          res.end('ok')
+
+          await new Promise<void>(r => res.stream.once('close', () => r()))
+
+          expect(getNodeResponseError(res)).toBe(null)
 
           resolve()
         }

--- a/packages/node/src/utils.ts
+++ b/packages/node/src/utils.ts
@@ -5,3 +5,8 @@ export function canWriteToNodeResponse(res: Stream.Writable | NodeHttpResponse):
   const stream = 'stream' in res ? res.stream : res
   return !stream.closed && !stream.destroyed && !stream.writableFinished && !stream.writableEnded
 }
+
+export function getNodeResponseError(res: Stream.Writable | NodeHttpResponse): Error | null {
+  const stream = 'stream' in res ? res.stream : res
+  return stream.errored
+}


### PR DESCRIPTION
`Http2ServerResponse` extends `Stream`, not `Writable`, so it has no `errored` property of its own — despite `@types/node` declaring one. Reading `res.errored` silently yielded `undefined` on HTTP/2, which made an errored response indistinguishable from a cleanly closed one. The error actually lives on `res.stream`.

## Fixes

- Failed HTTP/2 responses now reject instead of resolving successfully, so callers see the error rather than a phantom success.
- Body streams torn down after an HTTP/2 failure are destroyed with the real cause instead of no reason at all, so cleanup handlers and `finally` blocks receive it.
- `toAbortSignal` on an already-errored HTTP/2 response now starts aborted with the underlying error, instead of returning an un-aborted signal or a generic `AbortError`.

HTTP/1 behaviour is unchanged — `OutgoingMessage` defines its own `errored`, so that path was always correct. A new `getNodeResponseError` helper does the `res.stream` unwrap, mirroring what `canWriteToNodeResponse` already did.

## Testing

Covered at the helper level in `utils.test.ts` across HTTP/1 and HTTP/2, errored and normal-completion, plus an `toAbortSignal` regression test in `signal.test.ts`.

Each new test was confirmed to fail against the old `res.errored` read and pass with the fix. Reverting the unwrap fails exactly the three HTTP/2 tests while every HTTP/1 test keeps passing. The normal-completion case is what makes the helper-level placement worthwhile: it catches HTTP/2 returning `undefined` where `null` is expected, which a test going through `sendStandardResponse` could not see, since both values are falsy there.

Full suite: 792 passing across 49 files; typecheck and lint clean.

## Note for reviewers

Node's HTTP/2 compatibility layer also declines to forward `'error'` to the response object — only `'close'` fires. The *live* error listeners in `sendStandardResponse` and `toAbortSignal` therefore never fire on HTTP/2, so a mid-stream failure still resolves rather than rejects. That is the same blind spot on the event path rather than the state path, and it is left alone here because fixing it changes the success-path promise semantics and deserves its own PR.