### PR TITLE
fix(fetch): prevent __proto__ header from corrupting parsed headers object

### DIFF
--- a/packages/fetch/src/headers.test.ts
+++ b/packages/fetch/src/headers.test.ts
@@ -19,6 +19,19 @@ it('toStandardHeaders', () => {
   })
 })
 
+it('toStandardHeaders with a __proto__ header', () => {
+  const headers = new Headers()
+
+  headers.append('__proto__', 'polluted')
+  headers.append('content-type', 'application/json')
+
+  const standardHeaders = toStandardHeaders(headers)
+
+  expect(Object.getPrototypeOf(standardHeaders)).toBe(null)
+  expect(Object.getOwnPropertyDescriptor(standardHeaders, '__proto__')?.value).toBe('polluted')
+  expect(standardHeaders['content-type']).toBe('application/json')
+})
+
 it('toFetchHeaders', () => {
   const standardHeaders: StandardHeaders = {
     'content-type': 'application/json',

--- a/packages/fetch/src/headers.ts
+++ b/packages/fetch/src/headers.ts
@@ -4,7 +4,9 @@ import type { StandardHeaders } from '@standardserver/core'
  * Convert fetch headers to standard headers.
  */
 export function toStandardHeaders(headers: Headers): StandardHeaders {
-  const standardHeaders: StandardHeaders = {}
+  // Null prototype so header names like __proto__ become plain own
+  // properties instead of touching the object's prototype.
+  const standardHeaders: StandardHeaders = Object.create(null)
 
   headers.forEach((value, key) => {
     if (Array.isArray(standardHeaders[key])) {


### PR DESCRIPTION
A request carrying a `__proto__` header corrupted the object returned by `toStandardHeaders` in `@standardserver/fetch`. Reading `standardHeaders['__proto__']` returned the inherited `Object.prototype` instead of `undefined`, so the parser took the duplicate-header branch and assigned an array through the inherited `__proto__` setter — replacing the parsed object's prototype with that array and silently dropping the header value.

## Fixes

- `toStandardHeaders` now builds the result on a null-prototype object, so `__proto__` (and any other inherited name) is stored as a plain own property; the prototype can no longer be swapped out by request input.
- Added a regression test asserting the prototype stays null and the `__proto__` header value is preserved as an ordinary entry.

## Testing

- All 78 tests in the fetch package pass; `tsc --noEmit` is clean.