### PR TITLE
fix(core): escape backslashes in Content-Disposition quoted filenames

### DIFF
--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -17,6 +17,13 @@ describe('generateContentDisposition', () => {
     expect(generateContentDisposition('!@#$%^%^&*()\'".txt')).toEqual('inline; filename="!@#$%^%^&*()\'\\".txt"; filename*=utf-8\'\'!%40%23%24%25^%25^%26%2A%28%29%27%22.txt')
   })
 
+  it('escape \\ special char', () => {
+    expect(generateContentDisposition('a\\b.txt')).toEqual('inline; filename="a\\\\b.txt"; filename*=utf-8\'\'a%5Cb.txt')
+    // a trailing backslash must not escape the closing quote
+    expect(generateContentDisposition('a\\')).toEqual('inline; filename="a\\\\"; filename*=utf-8\'\'a%5C')
+    expect(generateContentDisposition('a\\"; injected=x')).toEqual('inline; filename="a\\\\\\"; injected=x"; filename*=utf-8\'\'a%5C%22%3B%20injected%3Dx')
+  })
+
   it('escape non-ASCII filenames', () => {
     expect(generateContentDisposition('テンプレ\'"ート.txt')).toEqual('inline; filename="____\'\\"__.txt"; filename*=utf-8\'\'%E3%83%86%E3%83%B3%E3%83%97%E3%83%AC%27%22%E3%83%BC%E3%83%88.txt')
   })
@@ -30,6 +37,8 @@ it('getFilenameFromContentDisposition', () => {
   expect(getFilenameFromContentDisposition('attachment; filename=""')).toEqual('')
   expect(getFilenameFromContentDisposition('attachment; filename="test.txt"')).toEqual('test.txt')
   expect(getFilenameFromContentDisposition('attachment; filename="!@#$%^%^&*()\'\\".txt"')).toEqual('!@#$%^%^&*()\'".txt')
+  expect(getFilenameFromContentDisposition('attachment; filename="a\\\\b.txt"')).toEqual('a\\b.txt')
+  expect(getFilenameFromContentDisposition('attachment; filename="a\\\\"')).toEqual('a\\')
 
   expect(getFilenameFromContentDisposition('attachment; filename*=utf-8\'\'')).toEqual('')
   expect(getFilenameFromContentDisposition('attachment; filename*=utf-8\'\'test.txt')).toEqual('test.txt')

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -2,7 +2,7 @@ import type { StandardHeaders, StandardUrl } from './types'
 import { toArray, tryDecodeURIComponent } from '@standardserver/shared'
 
 export function generateContentDisposition(filename: string): string {
-  const encodedFilename = filename.replace(/[^\x20-\x7E]/g, '_').replace(/"/g, '\\"')
+  const encodedFilename = filename.replace(/[^\x20-\x7E]/g, '_').replace(/[\\"]/g, '\\$&')
 
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent#encoding_for_content-disposition_and_link_headers
   const encodedFilenameStar = encodeURIComponent(filename)
@@ -19,9 +19,9 @@ export function getFilenameFromContentDisposition(contentDisposition: string): s
     return tryDecodeURIComponent(encodedFilenameStarMatch[2])
   }
 
-  const encodedFilenameMatch = contentDisposition.match(/filename="((?:\\"|[^"])*)"/i)
+  const encodedFilenameMatch = contentDisposition.match(/filename="((?:\\.|[^"\\])*)"/i)
   if (encodedFilenameMatch && typeof encodedFilenameMatch[1] === 'string') {
-    return encodedFilenameMatch[1].replace(/\\"/g, '"')
+    return encodedFilenameMatch[1].replace(/\\(.)/g, '$1')
   }
 }
 


### PR DESCRIPTION
The quoted-string escaper in `generateContentDisposition` escaped `"` but not `\`, so a filename ending in a backslash turned the closing quote into an escaped quote and let the rest of an attacker-controlled filename be smuggled into extra `Content-Disposition` parameters. Both characters are now escaped per the RFC 9110 §5.6.4 quoted-string rules, and `getFilenameFromContentDisposition` unescapes any quoted-pair so backslash filenames round-trip correctly.

## Fixes

- `filename="..."` values are now always valid quoted-strings — a trailing `\` or `\"; injected=x` payload can no longer break out of the quotes.
- Parsing now decodes `\\` (and any other quoted-pair), so generate → parse round-trips filenames containing backslashes.

## Impact

Low severity: CR/LF were already filtered and the disposition type is hardcoded, so this permitted parameter injection only — and in the reachable flow the attacker already controls the whole filename. Fixed as a correctness bug.

## Testing

- New tests cover backslash escaping, the trailing-backslash edge, the injection payload, and parser round-trips.
- Core, peer, node, and fetch body/utils suites pass (127 tests); workspace `type:check` and ESLint clean.