### PR TITLE
feat(aws-lambda): add AWS Lambda adapter with response streaming

### DIFF
--- a/packages/aws-lambda/README.md
+++ b/packages/aws-lambda/README.md
@@ -1,11 +1,11 @@
-# Standard Server
+# @standardserver/aws-lambda
 
 <div align="center">
   <a href="https://codecov.io/gh/middleapi/standardserver">
     <img alt="codecov" src="https://codecov.io/gh/middleapi/standardserver/branch/main/graph/badge.svg">
   </a>
-  <a href="https://www.npmjs.com/package/@standardserver/core">
-    <img alt="weekly downloads" src="https://img.shields.io/npm/dw/%40standardserver%2Fcore?logo=npm" />
+  <a href="https://www.npmjs.com/package/@standardserver/aws-lambda">
+    <img alt="weekly downloads" src="https://img.shields.io/npm/dw/%40standardserver%2Faws-lambda?logo=npm" />
   </a>
   <a href="https://app.codspeed.io/middleapi/standardserver?utm_source=badge">
     <img src="https://img.shields.io/endpoint?url=https://codspeed.io/badge.json" alt="CodSpeed" />
@@ -21,321 +21,97 @@
   </a>
 </div>
 
-**Standard Server** provides a unified interface for client-server communication over HTTP and message-based transports.
+`@standardserver/aws-lambda` adapts AWS Lambda events and response streams to the transport-agnostic request and response model defined by Standard Server.
+
+Standard Server provides a unified interface for client-server communication across HTTP and message-based transports. It lets you write handlers against the same request, response, body, and streaming primitives whether the underlying transport is the Fetch API, Node.js HTTP, HTTP/2, or a peer-style message channel.
+
+This package is the AWS Lambda adapter for that model. It converts an API Gateway proxy event — payload format version 1.0 or 2.0, the latter also used by Lambda Function URLs — into a `StandardLazyRequest`, and writes a `StandardResponse` back through the stream provided by `awslambda.streamifyResponse`, so streaming bodies such as server-sent events flow to the client as they are produced instead of being buffered.
+
+## Entry Point
+
+The package exports a single entry point:
+
+| Export                       | Purpose                                                    |
+| ---------------------------- | ---------------------------------------------------------- |
+| `@standardserver/aws-lambda` | AWS Lambda adapter helpers for events and response streams |
+
+## Package overview
+
+The main entry point exposes these helpers:
+
+| Group                   | Exports                                                                                                                                             | Purpose                                                     |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| Request and response    | `toStandardLazyRequest()`, `sendStandardResponse()`                                                                                                 | Adapt Lambda events and response streams to Standard Server |
+| Lower-level helpers     | `toStandardUrl()`, `toStandardHeaders()`, `getEventHeader()`, `toStandardBody()`, `toLambdaHeaders()`                                               | Convert individual pieces of an event                       |
+| Types and option shapes | `APIGatewayProxyEvent`, `APIGatewayProxyEventV2`, `AnyAPIGatewayProxyEvent`, `HttpResponseStream`, `AwsLambdaGlobal`, `SendStandardResponseOptions` | Type handler inputs and serializer options                  |
+
+`APIGatewayProxyEvent` and `APIGatewayProxyEventV2` are structural subsets of the same-named types from `@types/aws-lambda`, so events typed with either work; the adapter accepts both via `AnyAPIGatewayProxyEvent` and tells them apart by the top-level `httpMethod` field only payload format 1.0 carries. `AwsLambdaGlobal` describes the `awslambda` global the Lambda Node.js runtime injects — the package deliberately does not `declare global`, so importing it never pollutes your project's global types. Declare the global yourself where you need typed access to `awslambda.streamifyResponse`.
+
+## Server-side request handling
+
+Use `toStandardLazyRequest()` to convert the incoming event into a `StandardLazyRequest`, then `sendStandardResponse()` to write the resulting `StandardResponse` back through the response stream. The handler must be wrapped with `awslambda.streamifyResponse`, and the function must run on the AWS Lambda Node.js runtime with response streaming enabled.
 
 ```ts
-import type { StandardLazyRequest, StandardResponse, } from '@standardserver/core'
+import type { AwsLambdaGlobal } from '@standardserver/aws-lambda'
+import type { StandardLazyRequest, StandardResponse } from '@standardserver/core'
+import { sendStandardResponse, toStandardLazyRequest } from '@standardserver/aws-lambda'
 
-export async function handle(request: StandardLazyRequest): Promise<StandardResponse> {
+// injected by the AWS Lambda Node.js runtime when response streaming is enabled
+declare const awslambda: AwsLambdaGlobal
+
+async function handle(request: StandardLazyRequest): Promise<StandardResponse> {
   const body = await request.resolveBody()
 
   return {
     status: 200,
     headers: { 'content-type': 'application/json' },
-    async* body() { // <- SSE response
-      yield 'Hello, World!'
+    body: {
+      ok: true,
+      method: request.method,
+      url: request.url,
+      received: body,
     },
   }
 }
+
+export const handler = awslambda.streamifyResponse(async (event, responseStream, context) => {
+  const standardRequest = toStandardLazyRequest(event, responseStream)
+  const standardResponse = await handle(standardRequest)
+
+  await sendStandardResponse(responseStream, standardResponse, {/** options */})
+})
 ```
 
-## Why Standard Server?
+`sendStandardResponse()` sends the status, headers, and cookies as the response stream metadata prelude via `awslambda.HttpResponseStream.from()`, then streams the body. It resolves once the response is fully flushed, and rejects if the stream errors.
 
-Standard Server abstracts away the complexities of handling different communication protocols, allowing developers to focus on building their applications without worrying about the underlying transport mechanisms. It supports both HTTP and message-based transports, making it versatile for various use cases.
+> [!TIP]
+> When sending responses, you can pass additional options such as event-stream keep-alive.
 
-## Packages
+## Resolving Body
 
-| Package                      | Purpose                                 | Main entry points                                                                                     |
-| ---------------------------- | --------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `@standardserver/aws-lambda` | AWS Lambda adapter (response streaming) | `toStandardLazyRequest`, `sendStandardResponse`                                                       |
-| `@standardserver/core`       | Shared types, validators, and utilities | `StandardRequest`, `StandardLazyRequest`, `StandardResponse`, `StandardLazyResponse`                  |
-| `@standardserver/fastify`    | Fastify adapter                         | `toStandardLazyRequest`, `sendStandardResponse`                                                       |
-| `@standardserver/fetch`      | Fetch API adapter                       | `toStandardLazyRequest`, `toFetchResponse`, `toStandardLazyResponse`, `toFetchBody`, `toFetchHeaders` |
-| `@standardserver/node`       | Node.js HTTP/HTTP2 adapter              | `toStandardLazyRequest`, `sendStandardResponse`                                                       |
-| `@standardserver/peer`       | Message-based adapter                   | `ClientPeer`, `ServerPeer`, `encodePeerMessage`, `decodePeerMessage`                                  |
-
-## Standard Request and Response
-
-Standard Server defines four core types: `StandardRequest`, `StandardLazyRequest`, `StandardResponse`, and `StandardLazyResponse`. Together, they provide a consistent shape for transport-agnostic communication.
-
-| Field                | Type                                                 | Description                                       |
-| -------------------- | ---------------------------------------------------- | ------------------------------------------------- |
-| `method`             | `string`                                             | HTTP method (e.g., GET, POST)                     |
-| `url`                | `string`                                             | request URL not include origin and start with `/` |
-| `headers`            | `Record<string, string \| string[] \| undefined>`    | request headers as a lowercase-key-value pair     |
-| `body`               | `StandardBody`                                       | parsed body                                       |
-| `resolveBody(hint?)` | `(hint?: StandardBodyHint) => Promise<StandardBody>` | Lazily resolves the request body                  |
-| `status`             | `number`                                             | HTTP status code (e.g., 200, 404)                 |
-| `signal`             | `undefined \| AbortSignal`                           | signal related to request/response lifecycle      |
-
-### Standard Body
-
-Currently, `StandardBody` and `StandardBodyHint` can be one of the following types:
-
-| Type                         | Hint           | Description                | Content-Type                        |
-| ---------------------------- | -------------- | -------------------------- | ----------------------------------- |
-| `unknown`                    | `json`         | JSON-compatible value      | `application/json`                  |
-| `FormData`                   | `form-data`    | Multipart form submissions | `multipart/form-data`               |
-| `URLSearchParams`            | `url-encoded`  | URL-encoded forms          | `application/x-www-form-urlencoded` |
-| `AsyncIteratorObject`        | `event-stream` | Server-Sent Events (SSE)   | `text/event-stream`                 |
-| `ReadableStream<Uint8Array>` | `octet-stream` | Binary streaming           | any                                 |
-| `Blob` or `File`             | `file`         | Fixed-size binary payload  | any                                 |
-| `undefined`                  | `none`         | Empty body                 |                                     |
-
-### Resolving Body
-
-`resolveBody(hint?)` determines how to parse the body using the following priority:
+The event carries the request body as a fully buffered, optionally base64-encoded string. `resolveBody(hint?)` decodes it and determines how to parse it using the following priority:
 
 1. If `hint?` is provided, use it as the `StandardBodyHint`.
 2. Otherwise, if the `standard-server` header is present, use it as the `StandardBodyHint`.
 3. Otherwise, if `content-type` is one of the common types, parse accordingly.
 4. Otherwise, if `content-length` exists, treat the body as `file`; if not, treat it as `octet-stream`.
 
-For efficient communication, set the `standard-server` header to explicitly hint the body type, especially for file or binary streaming. For example, if you upload a file with a common `content-type` such as `application/json` but omit the `standard-server` header, the server may interpret it as JSON and parse it unexpectedly.
-
-```ts
-const response = await fetch('/upload', {
-  method: 'POST',
-  headers: {
-    'content-type': 'application/json',
-    'standard-server': 'file', // <- hint the body type to avoid misinterpretation
-  },
-  body: new Blob(['{"message": "Hello, world!"}'], { type: 'application/json' }),
-})
-```
-
-### JSON Body
-
-Standard Server treats primitive values, objects, and arrays as JSON.
-
-```ts
-import { StandardRequest } from '@standardserver/core'
-
-const request: StandardRequest = {
-  method: 'POST',
-  url: '/submit',
-  headers: {},
-  body: { name: 'John Doe', email: 'john.doe@example.com' },
-}
-```
-
-### FormData and URLSearchParams Body
-
-Standard Server treats [FormData](https://developer.mozilla.org/en-US/docs/Web/API/FormData) and [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) as form submissions.
-
-```ts
-import { StandardRequest } from '@standardserver/core'
-
-const requestWithURLSearchParams: StandardRequest = {
-  method: 'POST',
-  url: '/submit',
-  headers: {},
-  body: new URLSearchParams({ name: 'John Doe', email: 'john.doe@example.com' }),
-}
-
-const formData = new FormData()
-formData.append('name', 'John Doe')
-formData.append('file', new Blob(['Hello, World!'], { type: 'text/plain' }), 'hello.txt')
-
-const requestWithFormData: StandardRequest = {
-  method: 'POST',
-  url: '/submit',
-  headers: {},
-  body: formData,
-}
-```
-
 > [!TIP]
-> HTML forms submit data as `application/x-www-form-urlencoded` or `multipart/form-data`, so this is especially helpful here.
+> For efficient communication, set the `standard-server` header to explicitly hint the body type, especially for file or binary streaming. For example, if you upload a file with a common `content-type` such as `application/json` but omit the `standard-server` header, the server may interpret it as JSON and parse it unexpectedly.
 
-## File and Blob Body
+## Lambda behavior to be aware of
 
-Standard Server treats [File](https://developer.mozilla.org/en-US/docs/Web/API/File) and [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob) as fixed-size binary payloads.
+- **Response streaming must be enabled.** `sendStandardResponse()` relies on the `awslambda` global, which only exists on the AWS Lambda Node.js runtime, and on the metadata prelude of `awslambda.HttpResponseStream`, which the platform only interprets for streaming-enabled invocations.
+- **`set-cookie` is sent via metadata cookies.** Multiple cookies survive because they are sent through the dedicated `cookies` metadata field; every other multi-value header is joined with `, `.
+- **Request bodies are buffered.** API Gateway delivers the whole request body at once, so request-side streaming degrades to a single buffered chunk. Response-side streaming is real streaming.
+- **Payload format 1.0 query strings are re-encoded.** API Gateway delivers them url-decoded, so the adapter re-encodes them when reconstructing the standard url. Payload format 2.0 provides the already encoded `rawQueryString`, which is used as-is.
+- **Payload format 2.0 cookies are restored.** API Gateway strips the `cookie` header into the separate `cookies` field, and the adapter joins them back into a `cookie` header on the standard request.
 
-> [!NOTE]
-> Since `File` extends `Blob`, `resolveBody` always returns a `File` when representing either `File` or `Blob` bodies.
+## Learn more
 
-```ts
-import { StandardResponse } from '@standardserver/core'
+For the higher-level project overview, see the root [Standard Server README](../../README.md).
 
-const response: StandardResponse = {
-  status: 200,
-  headers: {
-    'content-disposition': [], // <- remove auto-set header
-  },
-  body: new File(['Hello, World!'], 'hello.txt', { type: 'text/plain' }),
-}
-```
-
-When sending a file or blob body, Standard Server automatically sets the `content-length`, `content-type`, `content-disposition`, and `standard-server` headers based on the provided body. You can override `content-disposition` by explicitly providing a header value, or remove it entirely by assigning an empty array.
-
-### Event-Stream Body
-
-Standard Server uses [AsyncIteratorObject](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncIterator) to represent an event stream body, and you can use `withEventMeta` to attach additional [SSE event metadata](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format) to each emitted event.
-
-```ts
-import { ErrorEvent, StandardResponse, withEventMeta } from '@standardserver/core'
-
-const response: StandardResponse = {
-  status: 200,
-  headers: {},
-  async* body() {
-    yield withEventMeta(
-      { message: 'Hello, World!' },
-      { id: '1', retry: 3000, comments: ['hidden'] },
-    )
-
-    throw ErrorEvent({ message: 'Something went wrong' })
-
-    return { message: 'This is the end of the stream' }
-  },
-}
-```
-
-Events are interpreted as follows: `yield` emits a `message`, `throw` emits an `error`, and `return` emits a `close` event. Note that `close` does not cause [EventSource](https://developer.mozilla.org/en-US/docs/Web/API/EventSource) to close the connection because it is not part of the SSE specification. However, when using Standard Server for client-side streaming, `close` is treated as the end of the stream, so the connection is closed and no reconnection is attempted.
-
-### Octet-Stream Body
-
-Standard Server uses [ReadableStream<Uint8Array>](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) to represent a binary streaming body.
-
-```ts
-import { StandardResponse } from '@standardserver/core'
-
-const response: StandardResponse = {
-  status: 200,
-  headers: {
-    'content-type': 'application/octet-stream',
-  },
-  body: new ReadableStream<Uint8Array>({
-    start(controller) {
-      const encoder = new TextEncoder()
-      controller.enqueue(encoder.encode('Hello, World!'))
-      controller.close()
-    },
-  }),
-}
-```
-
-When sending a binary streaming body, Standard Server automatically sets the `content-type` and `standard-server` headers. You can override `content-type` by providing an explicit header value, or remove it entirely by assigning an empty array.
-
-## HTTP Adapters
-
-Use `@standardserver/fetch` to integrate with the Fetch API. For detailed implementation, see the [Fetch API adapter documentation](./packages/fetch/README.md).
-
-```ts
-import { toFetchBody, toFetchHeaders, toFetchResponse, toStandardLazyRequest, toStandardLazyResponse } from '@standardserver/fetch'
-
-// server-side
-export async function handleFetchRequest(request: Request): Promise<Response> {
-  const standardLazyRequest = toStandardLazyRequest(request)
-  const standardResponse = await handle(standardLazyRequest)
-  return toFetchResponse(standardResponse, {/** options */})
-}
-
-// client-side
-export async function main() {
-  const standardRequest = {
-    method: 'GET',
-    url: '/api/data',
-    headers: {},
-    body: { message: 'Hello, World!' },
-  }
-
-  const [body, standardHeaders] = toFetchBody(standardRequest.body, standardRequest.headers, {/** options */})
-  const response = await fetch(standardRequest.url, {
-    method: standardRequest.method,
-    headers: toFetchHeaders(standardHeaders),
-    body,
-  })
-
-  const standardLazyResponse = toStandardLazyResponse(response)
-}
-```
-
-Use `@standardserver/node` to integrate with Node.js HTTP and HTTP/2. For implementation details, see the [Node.js adapter documentation](./packages/node/README.md).
-
-```ts
-import type { IncomingMessage, ServerResponse } from 'node:http'
-import { createServer } from 'node:http'
-
-const server = createServer(async (req, res) => {
-  const standardLazyRequest = toStandardLazyRequest(req)
-  const standardResponse = await handle(standardLazyRequest)
-  await sendStandardResponse(res, standardResponse, {/** options */})
-})
-```
-
-Use `@standardserver/fastify` to integrate with Fastify, over either HTTP or HTTP/2. It builds on the Node.js adapter, but writes the response through Fastify's reply so hooks and plugins keep working. For implementation details, see the [Fastify adapter documentation](./packages/fastify/README.md).
-
-```ts
-import { sendStandardResponse, toStandardLazyRequest } from '@standardserver/fastify'
-import Fastify from 'fastify'
-
-const fastify = Fastify()
-
-fastify.all('/*', async (req, reply) => {
-  const standardLazyRequest = toStandardLazyRequest(req, reply)
-  const standardResponse = await handle(standardLazyRequest)
-  await sendStandardResponse(reply, standardResponse, {/** options */})
-})
-```
-
-> [!TIP]
-> When sending requests or responses, you can pass additional options such as event-stream keep-alive.
-
-## Message-Based Adapters
-
-Unlike HTTP adapters, message-based adapters are built from the ground up to enable client-server communication through string or binary messages. They are ideal for WebSocket, MessagePort, or any custom transport implementations. For detailed implementation, see the [peer adapter documentation](./packages/peer/README.md).
-
-```ts
-import {
-  ClientPeer,
-  decodePeerMessage,
-  encodePeerMessage,
-  isClientPeerSendMessage,
-  isServerPeerSendMessage,
-  ServerPeer
-} from '@standardserver/peer'
-
-const { port1, port2 } = new MessageChannel()
-
-const clientPeer = new ClientPeer(async (message) => {
-  port1.postMessage(await encodePeerMessage(message, { /** options */ }))
-})
-
-const serverPeer = new ServerPeer(async (message) => {
-  port2.postMessage(await encodePeerMessage(message, { /** options */ }))
-})
-
-port1.addEventListener('message', async (event) => {
-  const decoded = decodePeerMessage(event.data, { /** options */ })
-  if (decoded.matched && isServerPeerSendMessage(decoded.message)) {
-    await clientPeer.message(decoded.message)
-  }
-})
-
-port2.addEventListener('message', async (event) => {
-  const decoded = decodePeerMessage(event.data, { /** options */ })
-  if (decoded.matched && isClientPeerSendMessage(decoded.message)) {
-    await serverPeer.message(decoded.message, async (standardLazyRequest) => {
-      const standardResponse = await handle(standardLazyRequest)
-      return standardResponse
-    })
-  }
-})
-
-port1.start()
-port2.start()
-
-const standardLazyResponse = await clientPeer.request({
-  method: 'GET',
-  url: '/ping',
-  headers: {},
-})
-```
-
-> [!TIP]
-> When encoding or decoding peer messages, you can pass additional options, such as `prefix`, to prevent collisions when the same peer is used for multiple purposes.
+For the Node.js primitives this adapter is built on, see the [Node.js adapter documentation](../node/README.md).
 
 ## Sponsors
 

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@standardserver/aws-lambda",
+  "type": "module",
+  "version": "0.6.0",
+  "license": "MIT",
+  "homepage": "https://standardserver.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/middleapi/standardserver.git",
+    "directory": "packages/aws-lambda"
+  },
+  "sideEffects": false,
+  "publishConfig": {
+    "exports": {
+      "./package.json": "./package.json",
+      ".": {
+        "types": "./dist/index.d.mts",
+        "import": "./dist/index.mjs",
+        "default": "./dist/index.mjs"
+      }
+    }
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "unbuild",
+    "type:check": "tsc -b"
+  },
+  "dependencies": {
+    "@standardserver/core": "workspace:*",
+    "@standardserver/fetch": "workspace:*",
+    "@standardserver/node": "workspace:*",
+    "@standardserver/shared": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/aws-lambda": "^8.10.162",
+    "@types/node": "^26.0.0"
+  }
+}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -39,6 +39,6 @@
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.162",
-    "@types/node": "^26.0.0"
+    "@types/node": "^26.1.2"
   }
 }

--- a/packages/aws-lambda/src/body.test.ts
+++ b/packages/aws-lambda/src/body.test.ts
@@ -1,0 +1,224 @@
+import type { AsyncIteratorClass } from '@standardserver/shared'
+import type { APIGatewayProxyEvent } from './types'
+import { Buffer } from 'node:buffer'
+import { toStandardBody } from './body'
+
+function event(override: Partial<APIGatewayProxyEvent>): APIGatewayProxyEvent {
+  return {
+    httpMethod: 'POST',
+    path: '/',
+    body: null,
+    isBase64Encoded: false,
+    ...override,
+  }
+}
+
+describe('toStandardBody', () => {
+  describe('empty', () => {
+    it('returns undefined when body is missing', async () => {
+      await expect(toStandardBody(event({ body: null }))).resolves.toBeUndefined()
+      await expect(toStandardBody(event({ body: undefined }))).resolves.toBeUndefined()
+    })
+
+    it('returns undefined when body is missing, even with content headers', async () => {
+      await expect(toStandardBody(event({
+        body: null,
+        multiValueHeaders: { 'Content-Type': ['application/json'] },
+      }))).resolves.toBeUndefined()
+    })
+
+    it('returns undefined when body is empty without content-type', async () => {
+      await expect(toStandardBody(event({ body: '' }))).resolves.toBeUndefined()
+    })
+
+    it('parses an empty body when content-type is present', async () => {
+      await expect(toStandardBody(event({
+        body: '',
+        multiValueHeaders: { 'Content-Type': ['application/x-www-form-urlencoded'] },
+      }))).resolves.toEqual(new URLSearchParams())
+    })
+
+    it('respects the none hint', async () => {
+      await expect(toStandardBody(event({
+        body: '{"foo":"bar"}',
+        multiValueHeaders: { 'Content-Type': ['application/json'] },
+      }), { hint: 'none' })).resolves.toBeUndefined()
+
+      await expect(toStandardBody(event({
+        body: '{"foo":"bar"}',
+        multiValueHeaders: { 'standard-server': ['none'] },
+      }))).resolves.toBeUndefined()
+    })
+
+    it('parses a missing body as empty when a hint is provided', async () => {
+      await expect(toStandardBody(event({ body: null }), { hint: 'json' })).resolves.toBeUndefined()
+      await expect(toStandardBody(event({ body: null }), { hint: 'url-search-params' })).resolves.toEqual(new URLSearchParams())
+    })
+  })
+
+  describe('json', () => {
+    it('parses json', async () => {
+      await expect(toStandardBody(event({
+        body: '{"foo":"bar"}',
+        multiValueHeaders: { 'Content-Type': ['application/json'] },
+      }))).resolves.toEqual({ foo: 'bar' })
+    })
+
+    it('parses json with content-type parameters', async () => {
+      await expect(toStandardBody(event({
+        body: '{"foo":"bar"}',
+        multiValueHeaders: { 'Content-Type': ['application/json; charset=utf-8'] },
+      }))).resolves.toEqual({ foo: 'bar' })
+    })
+
+    it('parses base64-encoded json', async () => {
+      await expect(toStandardBody(event({
+        body: Buffer.from('{"foo":"bar"}').toString('base64'),
+        isBase64Encoded: true,
+        multiValueHeaders: { 'Content-Type': ['application/json'] },
+      }))).resolves.toEqual({ foo: 'bar' })
+    })
+
+    it('parses empty json as undefined', async () => {
+      await expect(toStandardBody(event({
+        body: '',
+        multiValueHeaders: { 'Content-Type': ['application/json'] },
+      }))).resolves.toBeUndefined()
+    })
+  })
+
+  describe('url-search-params', () => {
+    it('parses url-encoded forms', async () => {
+      await expect(toStandardBody(event({
+        body: 'foo=bar&baz=qux',
+        multiValueHeaders: { 'Content-Type': ['application/x-www-form-urlencoded'] },
+      }))).resolves.toEqual(new URLSearchParams('foo=bar&baz=qux'))
+    })
+  })
+
+  describe('form-data', () => {
+    it('parses multipart forms', async () => {
+      const form = new FormData()
+      form.append('foo', 'bar')
+      form.append('file', new File(['content'], 'file.txt', { type: 'text/plain' }))
+
+      const encoded = new Response(form)
+
+      const standardBody = await toStandardBody(event({
+        body: Buffer.from(await encoded.arrayBuffer()).toString('base64'),
+        isBase64Encoded: true,
+        multiValueHeaders: { 'Content-Type': [encoded.headers.get('content-type')!] },
+      })) as FormData
+
+      expect(standardBody).toBeInstanceOf(FormData)
+      expect(standardBody.get('foo')).toBe('bar')
+      expect((standardBody.get('file') as File).name).toBe('file.txt')
+      await expect((standardBody.get('file') as File).text()).resolves.toBe('content')
+    })
+
+    it('rejects on form-data hint without content-type', async () => {
+      await expect(toStandardBody(event({
+        body: 'not-multipart',
+      }), { hint: 'form-data' })).rejects.toThrow()
+    })
+  })
+
+  describe('event-stream', () => {
+    it('parses server-sent events', async () => {
+      const standardBody = await toStandardBody(event({
+        body: ': \n\nevent: message\ndata: "foo"\n\nevent: close\ndata: "baz"\n\n',
+        multiValueHeaders: { 'Content-Type': ['text/event-stream'] },
+      })) as AsyncIteratorClass<unknown>
+
+      await expect(standardBody.next()).resolves.toEqual({ done: false, value: 'foo' })
+      await expect(standardBody.next()).resolves.toEqual({ done: true, value: 'baz' })
+    })
+  })
+
+  describe('octet-stream', () => {
+    it('streams the body on explicit hint', async () => {
+      const standardBody = await toStandardBody(event({
+        body: 'raw-data',
+        multiValueHeaders: {
+          'Content-Type': ['application/octet-stream'],
+          'standard-server': ['octet-stream'],
+        },
+      })) as ReadableStream<Uint8Array>
+
+      expect(standardBody).toBeInstanceOf(ReadableStream)
+      await expect(new Response(standardBody).text()).resolves.toBe('raw-data')
+    })
+  })
+
+  describe('file', () => {
+    it('parses file with filename from content-disposition', async () => {
+      const standardBody = await toStandardBody(event({
+        body: 'hello',
+        multiValueHeaders: {
+          'Content-Type': ['text/plain'],
+          'Content-Disposition': ['inline; filename="hello.txt"'],
+          'Content-Length': ['5'],
+        },
+      })) as File
+
+      expect(standardBody).toBeInstanceOf(File)
+      expect(standardBody.name).toBe('hello.txt')
+      expect(standardBody.type).toBe('text/plain')
+      await expect(standardBody.text()).resolves.toBe('hello')
+    })
+
+    it('treats a body with content-length but uncommon content-type as file', async () => {
+      const standardBody = await toStandardBody(event({
+        body: 'raw-data',
+        multiValueHeaders: { 'Content-Length': ['8'] },
+      })) as File
+
+      expect(standardBody).toBeInstanceOf(File)
+      expect(standardBody.name).toBe('blob')
+      expect(standardBody.type).toBe('')
+      await expect(standardBody.text()).resolves.toBe('raw-data')
+    })
+
+    it('treats a body without content-length as octet-stream', async () => {
+      const standardBody = await toStandardBody(event({
+        body: 'raw-data',
+      })) as ReadableStream<Uint8Array>
+
+      expect(standardBody).toBeInstanceOf(ReadableStream)
+      await expect(new Response(standardBody).text()).resolves.toBe('raw-data')
+    })
+
+    it('respects the file hint over the content-type', async () => {
+      const standardBody = await toStandardBody(event({
+        body: '{"foo":"bar"}',
+        multiValueHeaders: { 'Content-Type': ['application/json'] },
+      }), { hint: 'file' }) as File
+
+      expect(standardBody).toBeInstanceOf(File)
+      expect(standardBody.name).toBe('blob')
+      await expect(standardBody.text()).resolves.toBe('{"foo":"bar"}')
+    })
+  })
+
+  describe('hint', () => {
+    it('the hint option wins over the standard-server header', async () => {
+      await expect(toStandardBody(event({
+        body: '{"foo":"bar"}',
+        multiValueHeaders: {
+          'Content-Type': ['text/plain'],
+          'standard-server': ['file'],
+        },
+      }), { hint: 'json' })).resolves.toEqual({ foo: 'bar' })
+    })
+
+    it('the standard-server header wins over the content-type', async () => {
+      await expect(toStandardBody(event({
+        body: '{"foo":"bar"}',
+        multiValueHeaders: {
+          'Content-Type': ['text/plain'],
+          'standard-server': ['json'],
+        },
+      }))).resolves.toEqual({ foo: 'bar' })
+    })
+  })
+})

--- a/packages/aws-lambda/src/body.ts
+++ b/packages/aws-lambda/src/body.ts
@@ -1,0 +1,87 @@
+import type { StandardBody, StandardBodyHint } from '@standardserver/core'
+import type { AnyAPIGatewayProxyEvent } from './types'
+import { Buffer } from 'node:buffer'
+import { flattenStandardHeader, getFilenameFromContentDisposition } from '@standardserver/core'
+import { toAsyncIteratorObject } from '@standardserver/fetch'
+import { parseEmptyableJSON } from '@standardserver/shared'
+import { getEventHeader } from './headers'
+
+export interface ToStandardBodyOptions {
+  /**
+   * Hints on how the body should be parsed.
+   */
+  hint?: StandardBodyHint | undefined
+}
+
+/**
+ * Parses the fully buffered, optionally base64-encoded body of an API Gateway proxy event.
+ */
+export async function toStandardBody(
+  event: AnyAPIGatewayProxyEvent,
+  options: ToStandardBodyOptions = {},
+): Promise<StandardBody> {
+  const hint = options?.hint ?? flattenStandardHeader(getEventHeader(event, 'standard-server'))
+  const contentType = flattenStandardHeader(getEventHeader(event, 'content-type'))
+  const mimeType = contentType?.split(';')[0]?.trim()
+
+  if (hint === 'none' || (hint === undefined && typeof event.body !== 'string')) {
+    return undefined
+  }
+
+  const bytes: Uint8Array<ArrayBuffer> = typeof event.body !== 'string'
+    ? new Uint8Array()
+    : event.isBase64Encoded
+      ? Buffer.from(event.body, 'base64') as Uint8Array<ArrayBuffer>
+      : new TextEncoder().encode(event.body)
+
+  // the body is fully buffered so its emptiness is always known
+  if (hint === undefined && mimeType === undefined && bytes.length === 0) {
+    return undefined
+  }
+
+  if (hint === 'json' || (hint === undefined && mimeType === 'application/json')) {
+    return parseEmptyableJSON(new TextDecoder().decode(bytes))
+  }
+
+  if (hint === 'form-data' || (hint === undefined && mimeType === 'multipart/form-data')) {
+    return _bytesToFormData(bytes, contentType)
+  }
+
+  if (hint === 'url-search-params' || (hint === undefined && mimeType === 'application/x-www-form-urlencoded')) {
+    return new URLSearchParams(new TextDecoder().decode(bytes))
+  }
+
+  if (hint === 'event-stream' || (hint === undefined && mimeType === 'text/event-stream')) {
+    return toAsyncIteratorObject(_bytesToReadableStream(bytes))
+  }
+
+  if (hint === 'file' || (hint === undefined && flattenStandardHeader(getEventHeader(event, 'content-length')) !== undefined)) {
+    const contentDisposition = flattenStandardHeader(getEventHeader(event, 'content-disposition'))
+    const fileName = contentDisposition !== undefined
+      ? getFilenameFromContentDisposition(contentDisposition)
+      : undefined
+
+    return new File([bytes], fileName ?? 'blob', { type: contentType ?? '' })
+  }
+
+  return _bytesToReadableStream(bytes)
+}
+
+function _bytesToFormData(bytes: Uint8Array<ArrayBuffer>, contentType: string | undefined): Promise<FormData> {
+  const response = new Response(bytes, {
+    headers: {
+      'content-type': contentType ?? '',
+    },
+  })
+
+  return response.formData()
+}
+
+function _bytesToReadableStream(bytes: Uint8Array<ArrayBuffer>): ReadableStream<Uint8Array<ArrayBuffer>> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(bytes)
+      controller.close()
+    },
+  })
+}

--- a/packages/aws-lambda/src/headers.test.ts
+++ b/packages/aws-lambda/src/headers.test.ts
@@ -1,0 +1,210 @@
+import { getEventHeader, toLambdaHeaders, toStandardHeaders } from './headers'
+
+describe('getEventHeader', () => {
+  it('reads case-insensitively from multiValueHeaders (v1)', () => {
+    const event = {
+      httpMethod: 'GET',
+      path: '/',
+      headers: { 'content-type': 'ignored' },
+      multiValueHeaders: {
+        'Content-Type': ['application/json'],
+        'X-Multi': ['one', 'two'],
+        'X-Empty': [],
+        'X-Skipped': undefined,
+      },
+    }
+
+    expect(getEventHeader(event, 'Content-Type')).toEqual(['application/json'])
+    expect(getEventHeader(event, 'x-multi')).toEqual(['one', 'two'])
+    expect(getEventHeader(event, 'x-empty')).toBeUndefined()
+    expect(getEventHeader(event, 'x-skipped')).toBeUndefined()
+    expect(getEventHeader(event, 'x-missing')).toBeUndefined()
+  })
+
+  it('falls through to headers for keys multiValueHeaders does not carry (v1)', () => {
+    expect(getEventHeader({
+      httpMethod: 'GET',
+      path: '/',
+      headers: { 'X-Only-In-Headers': 'kept' },
+      multiValueHeaders: { 'Content-Type': ['application/json'] },
+    }, 'x-only-in-headers')).toBe('kept')
+  })
+
+  it('reads case-insensitively from headers (v1 fallback and v2)', () => {
+    const event = {
+      rawPath: '/',
+      requestContext: { http: { method: 'GET' } },
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Skipped': undefined,
+      },
+    }
+
+    expect(getEventHeader(event, 'Content-Type')).toBe('application/json')
+    expect(getEventHeader(event, 'x-skipped')).toBeUndefined()
+    expect(getEventHeader(event, 'x-missing')).toBeUndefined()
+
+    expect(getEventHeader({
+      httpMethod: 'GET',
+      path: '/',
+      multiValueHeaders: null,
+      headers: { 'X-Custom': 'value' },
+    }, 'x-custom')).toBe('value')
+  })
+
+  it('returns undefined when no headers are present', () => {
+    expect(getEventHeader({ httpMethod: 'GET', path: '/' }, 'content-type')).toBeUndefined()
+    expect(getEventHeader({ rawPath: '/', requestContext: { http: { method: 'GET' } } }, 'content-type')).toBeUndefined()
+  })
+
+  it('restores the cookie header from cookies (v2)', () => {
+    expect(getEventHeader({
+      rawPath: '/',
+      requestContext: { http: { method: 'GET' } },
+      cookies: ['foo=bar', 'bar=baz'],
+    }, 'Cookie')).toBe('foo=bar; bar=baz')
+
+    // a cookie header present in headers wins over the cookies field
+    expect(getEventHeader({
+      rawPath: '/',
+      requestContext: { http: { method: 'GET' } },
+      headers: { Cookie: 'a=b' },
+      cookies: ['foo=bar'],
+    }, 'cookie')).toBe('a=b')
+
+    expect(getEventHeader({
+      rawPath: '/',
+      requestContext: { http: { method: 'GET' } },
+      cookies: [],
+    }, 'cookie')).toBeUndefined()
+  })
+})
+
+describe('toStandardHeaders (v2)', () => {
+  it('lowercases keys and restores the cookie header', () => {
+    expect(toStandardHeaders({
+      rawPath: '/',
+      requestContext: { http: { method: 'GET' } },
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Custom': 'one, two',
+        'X-Skipped': undefined,
+      },
+      cookies: ['foo=bar', 'bar=baz'],
+    })).toEqual({
+      'content-type': 'application/json',
+      'x-custom': 'one, two',
+      'cookie': 'foo=bar; bar=baz',
+    })
+  })
+
+  it('ignores empty or missing cookies', () => {
+    expect(toStandardHeaders({
+      rawPath: '/',
+      requestContext: { http: { method: 'GET' } },
+      headers: { 'x-custom': 'value' },
+      cookies: [],
+    })).toEqual({
+      'x-custom': 'value',
+    })
+
+    expect(toStandardHeaders({
+      rawPath: '/',
+      requestContext: { http: { method: 'GET' } },
+    })).toEqual({})
+  })
+})
+
+describe('toStandardHeaders (v1)', () => {
+  it('merges both sources, preferring multiValueHeaders per key, and lowercases keys', () => {
+    expect(toStandardHeaders({
+      httpMethod: 'GET',
+      path: '/',
+      headers: {
+        'Content-Type': 'ignored in favor of multiValueHeaders',
+        'X-Only-In-Headers': 'kept',
+        'X-Skipped-Single': undefined,
+      },
+      multiValueHeaders: {
+        'Content-Type': ['application/json'],
+        'X-Custom': ['one', 'two'],
+        'X-Empty': [],
+        'X-Skipped': undefined,
+      },
+    })).toEqual({
+      'content-type': 'application/json',
+      'x-custom': ['one', 'two'],
+      'x-only-in-headers': 'kept',
+    })
+  })
+
+  it('merges multiValueHeaders keys differing only in case', () => {
+    expect(toStandardHeaders({
+      httpMethod: 'GET',
+      path: '/',
+      multiValueHeaders: {
+        'x-custom': ['one'],
+        'X-Custom': ['two', 'three'],
+      },
+    })).toEqual({
+      'x-custom': ['one', 'two', 'three'],
+    })
+  })
+
+  it('falls back to headers', () => {
+    expect(toStandardHeaders({
+      httpMethod: 'GET',
+      path: '/',
+      multiValueHeaders: null,
+      headers: {
+        'Content-Type': 'application/json',
+        'x-custom': 'value',
+        'x-skipped': undefined,
+      },
+    })).toEqual({
+      'content-type': 'application/json',
+      'x-custom': 'value',
+    })
+  })
+
+  it('returns an empty object when no headers are present', () => {
+    expect(toStandardHeaders({ httpMethod: 'GET', path: '/' })).toEqual({})
+  })
+
+  it('keeps __proto__ header as a plain own property', () => {
+    const headers = toStandardHeaders({
+      httpMethod: 'GET',
+      path: '/',
+      multiValueHeaders: JSON.parse('{"__proto__": ["injected"]}'),
+    })
+
+    expect(Object.getOwnPropertyDescriptor(headers, '__proto__')?.value).toBe('injected')
+    expect(Object.getPrototypeOf(headers)).toBe(null)
+  })
+})
+
+describe('toLambdaHeaders', () => {
+  it('joins multi-value headers and separates set-cookie', () => {
+    expect(toLambdaHeaders({
+      'content-type': 'application/json',
+      'x-custom': ['one', 'two'],
+      'x-skipped': undefined,
+      'set-cookie': ['foo=bar', 'bar=baz'],
+    })).toEqual([
+      {
+        'content-type': 'application/json',
+        'x-custom': 'one, two',
+      },
+      ['foo=bar', 'bar=baz'],
+    ])
+  })
+
+  it('supports a single set-cookie string case-insensitively', () => {
+    expect(toLambdaHeaders({
+      'Set-Cookie': 'foo=bar',
+    })).toEqual([
+      {},
+      ['foo=bar'],
+    ])
+  })
+})

--- a/packages/aws-lambda/src/headers.ts
+++ b/packages/aws-lambda/src/headers.ts
@@ -30,7 +30,7 @@ export function toStandardHeaders(event: AnyAPIGatewayProxyEvent): StandardHeade
       }
     }
 
-    if (event.cookies?.length) {
+    if (event.cookies?.length && standardHeaders['cookie'] === undefined) {
       append('cookie', [event.cookies.join('; ')])
     }
 

--- a/packages/aws-lambda/src/headers.ts
+++ b/packages/aws-lambda/src/headers.ts
@@ -1,0 +1,121 @@
+import type { StandardHeaders } from '@standardserver/core'
+import type { AnyAPIGatewayProxyEvent } from './types'
+import { toArray } from '@standardserver/shared'
+
+/**
+ * Convert API Gateway proxy event headers to standard headers.
+ *
+ * Payload format 1.0 merges `multiValueHeaders` and `headers`, preferring
+ * `multiValueHeaders` per key. Payload format 2.0 restores the `cookie`
+ * header from `cookies`.
+ */
+export function toStandardHeaders(event: AnyAPIGatewayProxyEvent): StandardHeaders {
+  const standardHeaders: StandardHeaders = Object.create(null)
+
+  const append = (key: string, values: string[]) => {
+    const lowerKey = key.toLowerCase()
+    const existing = standardHeaders[lowerKey]
+
+    const merged = existing === undefined ? values : [...toArray(existing), ...values]
+    standardHeaders[lowerKey] = merged.length === 1 ? merged[0] : merged
+  }
+
+  if (!('httpMethod' in event)) {
+    if (event.headers) {
+      for (const key in event.headers) {
+        const value = event.headers[key]
+        if (value !== undefined) {
+          append(key, [value])
+        }
+      }
+    }
+
+    if (event.cookies?.length) {
+      append('cookie', [event.cookies.join('; ')])
+    }
+
+    return standardHeaders
+  }
+
+  if (event.multiValueHeaders) {
+    for (const key in event.multiValueHeaders) {
+      const values = event.multiValueHeaders[key]
+      if (values !== undefined && values.length !== 0) {
+        append(key, values)
+      }
+    }
+  }
+
+  if (event.headers) {
+    for (const key in event.headers) {
+      const value = event.headers[key]
+      // `multiValueHeaders` is a superset of `headers` in real events,
+      // only fill in keys it does not already carry
+      if (value !== undefined && standardHeaders[key.toLowerCase()] === undefined) {
+        append(key, [value])
+      }
+    }
+  }
+
+  return standardHeaders
+}
+
+/**
+ * Read a single header from an API Gateway proxy event, case-insensitively.
+ */
+export function getEventHeader(event: AnyAPIGatewayProxyEvent, key: string): string | string[] | undefined {
+  key = key.toLowerCase()
+
+  if ('httpMethod' in event && event.multiValueHeaders) {
+    for (const k in event.multiValueHeaders) {
+      const headerValues = event.multiValueHeaders[k]
+      if (headerValues !== undefined && headerValues.length !== 0 && k.toLowerCase() === key) {
+        return headerValues
+      }
+    }
+  }
+
+  if (event.headers) {
+    for (const k in event.headers) {
+      const headerValue = event.headers[k]
+      if (headerValue !== undefined && k.toLowerCase() === key) {
+        return headerValue
+      }
+    }
+  }
+
+  if (key === 'cookie' && !('httpMethod' in event) && event.cookies?.length) {
+    return event.cookies.join('; ')
+  }
+
+  return undefined
+}
+
+/**
+ * Split standard headers into the `headers` and `cookies` metadata fields.
+ * `set-cookie` values are kept separate because joining them would corrupt them.
+ */
+export function toLambdaHeaders(standardHeaders: StandardHeaders): [
+  headers: Record<string, string>,
+  setCookies: string[],
+] {
+  const headers: Record<string, string> = Object.create(null)
+  const setCookies: string[] = []
+
+  for (const key in standardHeaders) {
+    const value = standardHeaders[key]
+
+    if (value === undefined) {
+      continue
+    }
+
+    if (key.toLowerCase() === 'set-cookie') {
+      setCookies.push(...toArray(value))
+    }
+    else {
+      headers[key] = Array.isArray(value) ? value.join(', ') : value
+    }
+  }
+
+  return [headers, setCookies]
+}

--- a/packages/aws-lambda/src/headers.ts
+++ b/packages/aws-lambda/src/headers.ts
@@ -30,7 +30,7 @@ export function toStandardHeaders(event: AnyAPIGatewayProxyEvent): StandardHeade
       }
     }
 
-    if (event.cookies?.length && standardHeaders['cookie'] === undefined) {
+    if (event.cookies?.length && standardHeaders.cookie === undefined) {
       append('cookie', [event.cookies.join('; ')])
     }
 

--- a/packages/aws-lambda/src/index.test.ts
+++ b/packages/aws-lambda/src/index.test.ts
@@ -1,0 +1,5 @@
+import * as index from '.'
+
+it('export something', () => {
+  expect(Object.keys(index).length).toBeGreaterThan(0)
+})

--- a/packages/aws-lambda/src/index.ts
+++ b/packages/aws-lambda/src/index.ts
@@ -1,0 +1,6 @@
+export * from './body'
+export * from './headers'
+export * from './request'
+export * from './response'
+export * from './types'
+export * from './url'

--- a/packages/aws-lambda/src/request.test.ts
+++ b/packages/aws-lambda/src/request.test.ts
@@ -1,0 +1,112 @@
+import type { APIGatewayProxyEvent, APIGatewayProxyEventV2, HttpResponseStream } from './types'
+import Stream from 'node:stream'
+import * as StandardServerNode from '@standardserver/node'
+import * as Body from './body'
+import * as Headers from './headers'
+import { toStandardLazyRequest } from './request'
+import * as Url from './url'
+
+const toStandardBodySpy = vi.spyOn(Body, 'toStandardBody')
+const toStandardHeadersSpy = vi.spyOn(Headers, 'toStandardHeaders')
+const toStandardUrlSpy = vi.spyOn(Url, 'toStandardUrl')
+const toAbortSignalSpy = vi.spyOn(StandardServerNode, 'toAbortSignal')
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+function createResponseStream(): HttpResponseStream {
+  const stream = new Stream.Writable({
+    write(chunk, encoding, callback) {
+      callback()
+    },
+  }) as HttpResponseStream
+
+  stream.setContentType = vi.fn()
+
+  return stream
+}
+
+describe('toStandardLazyRequest', () => {
+  const event: APIGatewayProxyEvent = {
+    httpMethod: 'POST',
+    path: '/example',
+    multiValueHeaders: { 'Content-Type': ['application/json'] },
+    multiValueQueryStringParameters: { foo: ['bar'] },
+    body: '{"foo":"bar"}',
+    isBase64Encoded: false,
+  }
+
+  it('works', async () => {
+    const responseStream = createResponseStream()
+
+    const standardRequest = toStandardLazyRequest(event, responseStream)
+
+    expect(toAbortSignalSpy).toBeCalledTimes(1)
+    expect(toAbortSignalSpy).toBeCalledWith(responseStream)
+    expect(standardRequest.signal).toBe(toAbortSignalSpy.mock.results[0]!.value)
+
+    expect(toStandardUrlSpy).toBeCalledTimes(1)
+    expect(toStandardUrlSpy).toBeCalledWith(event)
+    expect(standardRequest.url).toBe('/example?foo=bar')
+
+    expect(standardRequest.method).toBe('POST')
+
+    expect(standardRequest.headers).toEqual({ 'content-type': 'application/json' })
+    expect(toStandardHeadersSpy).toBeCalledTimes(1)
+    expect(toStandardHeadersSpy).toBeCalledWith(event)
+
+    await expect(standardRequest.resolveBody('json')).resolves.toEqual({ foo: 'bar' })
+    expect(toStandardBodySpy).toBeCalledTimes(1)
+    expect(toStandardBodySpy).toBeCalledWith(event, { hint: 'json' })
+  })
+
+  it('works with a v2 event', async () => {
+    const eventV2: APIGatewayProxyEventV2 = {
+      rawPath: '/example',
+      rawQueryString: 'foo=bar',
+      requestContext: { http: { method: 'PUT' } },
+      headers: { 'Content-Type': 'application/json' },
+      body: '{"foo":"bar"}',
+      isBase64Encoded: false,
+    }
+
+    const standardRequest = toStandardLazyRequest(eventV2, createResponseStream())
+
+    expect(standardRequest.method).toBe('PUT')
+    expect(standardRequest.url).toBe('/example?foo=bar')
+    expect(standardRequest.headers).toEqual({ 'content-type': 'application/json' })
+    await expect(standardRequest.resolveBody()).resolves.toEqual({ foo: 'bar' })
+  })
+
+  it('headers is lazy and can override', () => {
+    const lazyRequest = toStandardLazyRequest(event, createResponseStream())
+
+    expect(toStandardHeadersSpy).toBeCalledTimes(0)
+    lazyRequest.headers = { overrided: '1' }
+    expect(lazyRequest.headers).toEqual({ overrided: '1' }) // can override before access
+    expect(toStandardHeadersSpy).toBeCalledTimes(0)
+
+    const lazyRequest2 = toStandardLazyRequest(event, createResponseStream())
+    expect(lazyRequest2.headers).toEqual(toStandardHeadersSpy.mock.results[0]!.value)
+    expect(lazyRequest2.headers).toEqual(toStandardHeadersSpy.mock.results[0]!.value) // ensure cached
+    expect(toStandardHeadersSpy).toBeCalledTimes(1)
+
+    lazyRequest2.headers = { overrided: '2' } // can override after access
+    expect(lazyRequest2.headers).toEqual({ overrided: '2' })
+  })
+
+  it('signal aborts when the response stream closes early', async () => {
+    const responseStream = createResponseStream()
+
+    const standardRequest = toStandardLazyRequest(event, responseStream)
+
+    expect(standardRequest.signal!.aborted).toBe(false)
+
+    responseStream.destroy()
+
+    await vi.waitFor(() => {
+      expect(standardRequest.signal!.aborted).toBe(true)
+    })
+  })
+})

--- a/packages/aws-lambda/src/request.ts
+++ b/packages/aws-lambda/src/request.ts
@@ -1,0 +1,34 @@
+import type { StandardLazyRequest } from '@standardserver/core'
+import type { AnyAPIGatewayProxyEvent, HttpResponseStream } from './types'
+import { toAbortSignal } from '@standardserver/node'
+import { toStandardBody } from './body'
+import { toStandardHeaders } from './headers'
+import { toStandardUrl } from './url'
+
+/**
+ * Convert an API Gateway proxy event to a standard lazy request.
+ */
+export function toStandardLazyRequest(
+  event: AnyAPIGatewayProxyEvent,
+  responseStream: HttpResponseStream,
+): StandardLazyRequest {
+  // DON'T lazy load signal, because we need register event listener as soon as possible
+  // to make the signal abort in time
+  const signal = toAbortSignal(responseStream)
+
+  return {
+    url: toStandardUrl(event),
+    method: 'httpMethod' in event ? event.httpMethod : event.requestContext.http.method,
+    get headers() {
+      // lazy headers to improve performance
+      const headers = toStandardHeaders(event)
+      Object.defineProperty(this, 'headers', { value: headers, writable: true })
+      return headers
+    },
+    set headers(value) {
+      Object.defineProperty(this, 'headers', { value, writable: true })
+    },
+    resolveBody: hint => toStandardBody(event, { hint }),
+    signal,
+  }
+}

--- a/packages/aws-lambda/src/response.test.ts
+++ b/packages/aws-lambda/src/response.test.ts
@@ -1,0 +1,305 @@
+import type { StandardResponse } from '@standardserver/core'
+import type { HttpResponseStream } from './types'
+import { Buffer } from 'node:buffer'
+import Stream from 'node:stream'
+import * as StandardServerNode from '@standardserver/node'
+import { sendStandardResponse } from './response'
+
+const toNodeHttpBodySpy = vi.spyOn(StandardServerNode, 'toNodeHttpBody')
+
+const DELIMITER = new Uint8Array(8)
+
+const fromSpy = vi.fn((responseStream: HttpResponseStream, metadata: Record<string, unknown>) => {
+  // mimics what the lambda runtime does: send the metadata prelude
+  // ahead of the body on the very same stream
+  responseStream.setContentType('application/vnd.awslambda.http-integration-response')
+  responseStream.write(JSON.stringify(metadata))
+  responseStream.write(DELIMITER)
+  return responseStream
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.stubGlobal('awslambda', { HttpResponseStream: { from: fromSpy } })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function createResponseStream(): HttpResponseStream & { chunks: Buffer[] } {
+  const stream = new Stream.Writable({
+    write(chunk, encoding, callback) {
+      stream.chunks.push(chunk)
+      callback()
+    },
+  }) as HttpResponseStream & { chunks: Buffer[] }
+
+  stream.chunks = []
+  stream.setContentType = vi.fn()
+
+  return stream
+}
+
+function metadataOf(stream: HttpResponseStream & { chunks: Buffer[] }): Record<string, unknown> {
+  return JSON.parse(stream.chunks[0]!.toString())
+}
+
+function bodyOf(stream: HttpResponseStream & { chunks: Buffer[] }): string {
+  return Buffer.concat(stream.chunks.slice(2)).toString()
+}
+
+describe('sendStandardResponse', () => {
+  it('buffered (empty)', async () => {
+    const responseStream = createResponseStream()
+
+    const options = { eventStream: { keepAlive: { enabled: true } } }
+    await sendStandardResponse(responseStream, {
+      status: 207,
+      headers: {
+        'x-custom-header': 'custom-value',
+      },
+      body: undefined,
+    }, options)
+
+    expect(toNodeHttpBodySpy).toBeCalledTimes(1)
+    expect(toNodeHttpBodySpy).toBeCalledWith(undefined, {
+      'x-custom-header': 'custom-value',
+    }, options)
+
+    expect(fromSpy).toBeCalledTimes(1)
+    expect(metadataOf(responseStream)).toEqual({
+      statusCode: 207,
+      headers: {
+        'x-custom-header': 'custom-value',
+      },
+      cookies: [],
+    })
+
+    expect(bodyOf(responseStream)).toBe('')
+    expect(responseStream.writableEnded).toBe(true)
+  })
+
+  it('buffered (json)', async () => {
+    const responseStream = createResponseStream()
+
+    await sendStandardResponse(responseStream, {
+      status: 200,
+      headers: {
+        'x-custom-header': 'custom-value',
+        'set-cookie': ['foo=bar', 'bar=baz'],
+      },
+      body: { foo: 'bar' },
+    })
+
+    expect(metadataOf(responseStream)).toEqual({
+      statusCode: 200,
+      headers: {
+        'content-type': 'application/json',
+        'x-custom-header': 'custom-value',
+      },
+      cookies: ['foo=bar', 'bar=baz'],
+    })
+
+    expect(bodyOf(responseStream)).toBe('{"foo":"bar"}')
+    expect(responseStream.writableEnded).toBe(true)
+  })
+
+  it('chunked (async generator)', async () => {
+    const responseStream = createResponseStream()
+
+    async function* gen() {
+      yield 'foo'
+      yield 'bar'
+      return 'baz'
+    }
+
+    await sendStandardResponse(responseStream, {
+      status: 200,
+      headers: {},
+      body: gen(),
+    })
+
+    expect(metadataOf(responseStream)).toMatchObject({
+      statusCode: 200,
+      headers: {
+        'content-type': 'text/event-stream',
+      },
+    })
+
+    expect(bodyOf(responseStream)).toBe(': \n\nevent: message\ndata: "foo"\n\nevent: message\ndata: "bar"\n\nevent: close\ndata: "baz"\n\n')
+    expect(responseStream.writableEnded).toBe(true)
+  })
+
+  it('chunked (octet-stream)', async () => {
+    const responseStream = createResponseStream()
+
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('chunk1'))
+        controller.enqueue(new TextEncoder().encode('chunk2'))
+        controller.close()
+      },
+    })
+
+    await sendStandardResponse(responseStream, {
+      status: 200,
+      headers: {},
+      body: stream,
+    })
+
+    expect(metadataOf(responseStream)).toMatchObject({
+      statusCode: 200,
+      headers: {
+        'content-type': 'application/octet-stream',
+      },
+    })
+
+    expect(bodyOf(responseStream)).toBe('chunk1chunk2')
+    expect(responseStream.writableEnded).toBe(true)
+  })
+
+  it('destroys the response stream when the body stream errors during streaming', async () => {
+    const responseStream = createResponseStream()
+
+    const error = new Error('TEST')
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('chunk1'))
+        controller.error(error)
+      },
+    })
+
+    await expect(sendStandardResponse(responseStream, {
+      status: 200,
+      headers: {},
+      body: stream,
+    })).rejects.toThrow('TEST')
+
+    expect(responseStream.destroyed).toBe(true)
+    expect(responseStream.errored).toBe(error)
+  })
+
+  it('destroys the body when the response stream closes while streaming', async () => {
+    const responseStream = createResponseStream()
+
+    let clean = false
+    const standardResponse: StandardResponse = {
+      body: (async function* () {
+        try {
+          yield 1
+          await new Promise(r => setTimeout(r, 100))
+          yield 2
+          await new Promise(r => setTimeout(r, 9999999))
+          yield 3
+        }
+        finally {
+          clean = true
+        }
+      })(),
+      headers: {},
+      status: 200,
+    }
+
+    const sendPromise = expect(sendStandardResponse(responseStream, standardResponse)).rejects.toThrow('test')
+
+    await vi.waitFor(() => {
+      expect(bodyOf(responseStream)).toContain('data: 1')
+    })
+
+    responseStream.destroy(new Error('test'))
+
+    await vi.waitFor(() => {
+      expect(clean).toBe(true)
+    })
+
+    await sendPromise
+  })
+
+  it('destroys the body without error when the response stream closes cleanly while streaming', async () => {
+    const responseStream = createResponseStream()
+
+    let clean = false
+    const standardResponse: StandardResponse = {
+      body: (async function* () {
+        try {
+          yield 1
+          await new Promise(r => setTimeout(r, 100))
+          yield 2
+          await new Promise(r => setTimeout(r, 9999999))
+          yield 3
+        }
+        finally {
+          clean = true
+        }
+      })(),
+      headers: {},
+      status: 200,
+    }
+
+    const sendPromise = sendStandardResponse(responseStream, standardResponse)
+
+    await vi.waitFor(() => {
+      expect(bodyOf(responseStream)).toContain('data: 1')
+    })
+
+    responseStream.destroy()
+
+    await vi.waitFor(() => {
+      expect(clean).toBe(true)
+    })
+
+    await sendPromise
+  })
+
+  describe('response stream closed before sending', () => {
+    it('resolves and destroys the body', async () => {
+      const responseStream = createResponseStream()
+      responseStream.destroy()
+
+      await vi.waitFor(() => {
+        expect(responseStream.closed).toBe(true)
+      })
+
+      let clean = false
+      const standardResponse: StandardResponse = {
+        body: (async function* () {
+          try {
+            yield 1
+          }
+          finally {
+            clean = true
+          }
+        })(),
+        headers: {},
+        status: 200,
+      }
+
+      await expect(sendStandardResponse(responseStream, standardResponse)).resolves.toBeUndefined()
+
+      await vi.waitFor(() => {
+        expect(clean).toBe(true)
+      })
+
+      expect(fromSpy).not.toHaveBeenCalled()
+    })
+
+    it('rejects when the response stream was destroyed with an error', async () => {
+      const responseStream = createResponseStream()
+      responseStream.once('error', () => {})
+      responseStream.destroy(new Error('test'))
+
+      await vi.waitFor(() => {
+        expect(responseStream.closed).toBe(true)
+      })
+
+      await expect(sendStandardResponse(responseStream, {
+        status: 200,
+        headers: {},
+        body: { foo: 'bar' },
+      })).rejects.toThrow('test')
+
+      expect(fromSpy).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/aws-lambda/src/response.ts
+++ b/packages/aws-lambda/src/response.ts
@@ -1,0 +1,80 @@
+import type { StandardResponse } from '@standardserver/core'
+import type { ToNodeHttpBodyOptions } from '@standardserver/node'
+import type { AwsLambdaGlobal, HttpResponseStream } from './types'
+import { canWriteToNodeResponse, getNodeResponseError, toNodeHttpBody } from '@standardserver/node'
+import { toLambdaHeaders } from './headers'
+
+/**
+ * Injected by the Lambda runtime when response streaming is enabled.
+ * Declared module-locally to keep the consumer's global types clean.
+ */
+declare const awslambda: AwsLambdaGlobal
+
+export interface SendStandardResponseOptions extends ToNodeHttpBodyOptions {
+}
+
+/**
+ * Send a standard response through the stream `awslambda.streamifyResponse` provides.
+ *
+ * Requires the Lambda Node.js runtime with response streaming enabled.
+ */
+export async function sendStandardResponse(
+  responseStream: HttpResponseStream,
+  standardResponse: StandardResponse,
+  options: SendStandardResponseOptions = {},
+): Promise<void> {
+  const [resBody, resHeaders] = toNodeHttpBody(standardResponse.body, standardResponse.headers, options)
+
+  return new Promise((resolve, reject) => {
+    if (!canWriteToNodeResponse(responseStream)) {
+      const error = getNodeResponseError(responseStream)
+
+      if (typeof resBody === 'object' && !resBody.closed) {
+        resBody.on('error', reject)
+        resBody.destroy(error ?? undefined)
+      }
+
+      if (error) {
+        reject(error)
+      }
+      else {
+        resolve()
+      }
+
+      return
+    }
+
+    const [headers, setCookies] = toLambdaHeaders(resHeaders)
+
+    // sends the metadata prelude (status, headers, cookies) and
+    // returns the stream the body should be written to
+    const res = awslambda.HttpResponseStream.from(responseStream, {
+      statusCode: standardResponse.status,
+      headers,
+      cookies: setCookies,
+    })
+
+    res.once('error', reject)
+    res.once('close', resolve)
+
+    if (resBody === undefined) {
+      // NOTE: Lambda functions don't allow passing undefined to `res.end`
+      res.end()
+    }
+    else if (typeof resBody === 'string') {
+      res.end(resBody)
+    }
+    else {
+      res.once('close', () => {
+        if (!resBody.closed) {
+          resBody.destroy(getNodeResponseError(res) ?? undefined)
+        }
+      })
+
+      // WARNING: errors that occur here are silently ignored and not reported to the Promise
+      resBody.once('error', error => res.destroy(error))
+
+      resBody.pipe(res)
+    }
+  })
+}

--- a/packages/aws-lambda/src/types.test-d.ts
+++ b/packages/aws-lambda/src/types.test-d.ts
@@ -1,0 +1,21 @@
+import type * as awsLambda from 'aws-lambda'
+import type { AnyAPIGatewayProxyEvent, APIGatewayProxyEvent, APIGatewayProxyEventV2, HttpResponseStream } from './types'
+
+it('APIGatewayProxyEvent', () => {
+  expectTypeOf<awsLambda.APIGatewayProxyEvent>().toExtend<APIGatewayProxyEvent>()
+  expectTypeOf<awsLambda.APIGatewayProxyEvent>().not.toExtend<APIGatewayProxyEventV2>()
+})
+
+it('APIGatewayProxyEventV2', () => {
+  expectTypeOf<awsLambda.APIGatewayProxyEventV2>().toExtend<APIGatewayProxyEventV2>()
+  expectTypeOf<awsLambda.APIGatewayProxyEventV2>().not.toExtend<APIGatewayProxyEvent>()
+})
+
+it('AnyAPIGatewayProxyEvent', () => {
+  const _v1: AnyAPIGatewayProxyEvent = {} as awsLambda.APIGatewayProxyEvent
+  const _v2: AnyAPIGatewayProxyEvent = {} as awsLambda.APIGatewayProxyEventV2
+})
+
+it('HttpResponseStream', () => {
+  expectTypeOf<Parameters<awsLambda.StreamifyHandler>[1]>().toExtend<HttpResponseStream>()
+})

--- a/packages/aws-lambda/src/types.ts
+++ b/packages/aws-lambda/src/types.ts
@@ -1,0 +1,111 @@
+import type { Writable } from 'node:stream'
+
+/**
+ * AWS API Gateway proxy event, payload format 1.0.
+ *
+ * A structural subset of the same-named type from `@types/aws-lambda`.
+ */
+export interface APIGatewayProxyEvent {
+  /**
+   * @example 'GET', 'POST', etc.
+   */
+  httpMethod: string
+  /**
+   * @example '/example'
+   */
+  path: string
+  /**
+   * Keys can be any case.
+   */
+  headers?: Record<string, string | undefined> | null
+  /**
+   * Preferred over `headers`, it can carry duplicated headers.
+   */
+  multiValueHeaders?: Record<string, string[] | undefined> | null
+  /**
+   * Values are already url-decoded.
+   */
+  queryStringParameters?: Record<string, string | undefined> | null
+  /**
+   * Preferred over `queryStringParameters`, it can carry duplicated parameters.
+   */
+  multiValueQueryStringParameters?: Record<string, string[] | undefined> | null
+  /**
+   * Base64-encoded when `isBase64Encoded` is `true`.
+   */
+  body?: string | null
+  isBase64Encoded?: boolean
+}
+
+/**
+ * AWS API Gateway proxy event, payload format 2.0, also used by Lambda Function URLs.
+ *
+ * A structural subset of the same-named type from `@types/aws-lambda`.
+ */
+export interface APIGatewayProxyEventV2 {
+  /**
+   * @example '/example'
+   */
+  rawPath: string
+  /**
+   * Already url-encoded, without the leading `?`.
+   */
+  rawQueryString?: string
+  /**
+   * Keys can be any case, duplicated headers arrive joined with commas.
+   */
+  headers?: Record<string, string | undefined> | null
+  /**
+   * Extracted from the `cookie` header.
+   */
+  cookies?: string[] | null
+  requestContext: {
+    http: {
+      /**
+       * @example 'GET', 'POST', etc.
+       */
+      method: string
+    }
+  }
+  /**
+   * Base64-encoded when `isBase64Encoded` is `true`.
+   */
+  body?: string | null
+  isBase64Encoded?: boolean
+}
+
+/**
+ * Any supported API Gateway proxy event.
+ * Payload format 1.0 is detected by its top-level `httpMethod` field.
+ */
+export type AnyAPIGatewayProxyEvent = APIGatewayProxyEvent | APIGatewayProxyEventV2
+
+/**
+ * The stream `awslambda.streamifyResponse` provides to write the response to.
+ */
+export interface HttpResponseStream extends Writable {
+  setContentType: (contentType: string) => void
+}
+
+/**
+ * Shape of the `awslambda` global the Lambda Node.js runtime injects
+ * when response streaming is enabled.
+ *
+ * Not declared globally to keep the consumer's global types clean,
+ * declare it yourself: `declare const awslambda: AwsLambdaGlobal`
+ */
+export interface AwsLambdaGlobal {
+  streamifyResponse<TEvent = unknown, TContext = unknown>(
+    handler: (event: TEvent, responseStream: HttpResponseStream, context: TContext) => Promise<void> | void,
+  ): (event: TEvent, responseStream: HttpResponseStream, context: TContext) => Promise<void> | void
+
+  HttpResponseStream: {
+    /**
+     * Sends the metadata prelude and returns the stream to write the body to.
+     */
+    from(
+      responseStream: HttpResponseStream,
+      metadata: { statusCode: number, headers: Record<string, string>, cookies: string[] } & Record<string, unknown>,
+    ): HttpResponseStream
+  }
+}

--- a/packages/aws-lambda/src/url.test.ts
+++ b/packages/aws-lambda/src/url.test.ts
@@ -1,0 +1,94 @@
+import { toStandardUrl } from './url'
+
+describe('toStandardUrl (v2)', () => {
+  it('works without query string', () => {
+    expect(toStandardUrl({
+      rawPath: '/example',
+      requestContext: { http: { method: 'GET' } },
+    })).toBe('/example')
+
+    expect(toStandardUrl({
+      rawPath: '/example',
+      rawQueryString: '',
+      requestContext: { http: { method: 'GET' } },
+    })).toBe('/example')
+  })
+
+  it('adds a leading slash when missing', () => {
+    expect(toStandardUrl({
+      rawPath: 'example',
+      requestContext: { http: { method: 'GET' } },
+    })).toBe('/example')
+  })
+
+  it('uses rawQueryString as-is', () => {
+    expect(toStandardUrl({
+      rawPath: '/example',
+      rawQueryString: 'foo=bar&foo=baz&a+key=a+value%26%3D%23',
+      requestContext: { http: { method: 'GET' } },
+    })).toBe('/example?foo=bar&foo=baz&a+key=a+value%26%3D%23')
+  })
+})
+
+describe('toStandardUrl (v1)', () => {
+  it('works without query string', () => {
+    expect(toStandardUrl({ httpMethod: 'GET', path: '/example' })).toBe('/example')
+  })
+
+  it('detects v1 by the top-level httpMethod field', () => {
+    // a v1 event carries a requestContext too, it must not be mistaken for v2
+    expect(toStandardUrl({
+      httpMethod: 'GET',
+      path: '/example',
+      requestContext: {},
+      queryStringParameters: { foo: 'bar' },
+    } as any)).toBe('/example?foo=bar')
+  })
+
+  it('adds a leading slash when missing', () => {
+    expect(toStandardUrl({ httpMethod: 'GET', path: 'example' })).toBe('/example')
+  })
+
+  it('merges both sources, preferring multiValueQueryStringParameters per key', () => {
+    expect(toStandardUrl({
+      httpMethod: 'GET',
+      path: '/example',
+      queryStringParameters: { foo: 'ignored', only: 'kept' },
+      multiValueQueryStringParameters: { foo: ['bar', 'baz'], hello: ['world'] },
+    })).toBe('/example?foo=bar&foo=baz&hello=world&only=kept')
+  })
+
+  it('skips undefined multiValueQueryStringParameters values', () => {
+    expect(toStandardUrl({
+      httpMethod: 'GET',
+      path: '/example',
+      multiValueQueryStringParameters: { foo: ['bar'], skipped: undefined },
+    })).toBe('/example?foo=bar')
+  })
+
+  it('falls back to queryStringParameters', () => {
+    expect(toStandardUrl({
+      httpMethod: 'GET',
+      path: '/example',
+      queryStringParameters: { foo: 'bar', empty: '', skipped: undefined },
+      multiValueQueryStringParameters: null,
+    })).toBe('/example?foo=bar&empty=')
+  })
+
+  it('re-encodes decoded query string parameters', () => {
+    expect(toStandardUrl({
+      httpMethod: 'GET',
+      path: '/example',
+      multiValueQueryStringParameters: { 'a key': ['a value&=#'] },
+    })).toBe(`/example?${new URLSearchParams({ 'a key': 'a value&=#' })}`)
+  })
+
+  it('ignores empty query containers', () => {
+    expect(toStandardUrl({
+      httpMethod: 'GET',
+      path: '/example',
+      queryStringParameters: null,
+      multiValueQueryStringParameters: {},
+    })).toBe('/example')
+  })
+})

--- a/packages/aws-lambda/src/url.ts
+++ b/packages/aws-lambda/src/url.ts
@@ -1,0 +1,43 @@
+import type { StandardUrl } from '@standardserver/core'
+import type { AnyAPIGatewayProxyEvent } from './types'
+
+/**
+ * Build a standard url from an API Gateway proxy event.
+ *
+ * Payload format 1.0 query parameters are re-encoded (delivered url-decoded),
+ * payload format 2.0's `rawQueryString` is used as-is.
+ */
+export function toStandardUrl(event: AnyAPIGatewayProxyEvent): StandardUrl {
+  if (!('httpMethod' in event)) {
+    const pathname = `${event.rawPath.startsWith('/') ? '' : '/'}${event.rawPath}` as `/${string}`
+
+    return event.rawQueryString ? `${pathname}?${event.rawQueryString}` : pathname
+  }
+
+  const pathname = `${event.path.startsWith('/') ? '' : '/'}${event.path}` as `/${string}`
+
+  const query = new URLSearchParams()
+
+  if (event.multiValueQueryStringParameters) {
+    for (const key in event.multiValueQueryStringParameters) {
+      for (const value of event.multiValueQueryStringParameters[key] ?? []) {
+        query.append(key, value)
+      }
+    }
+  }
+
+  if (event.queryStringParameters) {
+    for (const key in event.queryStringParameters) {
+      const value = event.queryStringParameters[key]
+      // `multiValueQueryStringParameters` is a superset of `queryStringParameters`
+      // in real events, only fill in keys it does not already carry
+      if (value !== undefined && !query.has(key)) {
+        query.append(key, value)
+      }
+    }
+  }
+
+  const search = query.toString()
+
+  return search === '' ? pathname : `${pathname}?${search}`
+}

--- a/packages/aws-lambda/tsconfig.json
+++ b/packages/aws-lambda/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.lib.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "references": [
+    { "path": "../node" }
+  ],
+  "include": ["./package.json", "src"],
+  "exclude": [
+    "**/*.test.*",
+    "**/*.test-d.ts",
+    "**/*.bench.*",
+    "**/__tests__/**",
+    "**/__mocks__/**",
+    "**/__snapshots__/**"
+  ]
+}

--- a/packages/fastify/package.json
+++ b/packages/fastify/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@fastify/cookie": "^11.1.2",
-    "@types/node": "^26.0.0",
+    "@types/node": "^26.1.2",
     "@types/supertest": "^7.2.1",
     "fastify": "^5.11.0",
     "supertest": "^7.1.4"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -37,7 +37,7 @@
     "@standardserver/shared": "workspace:*"
   },
   "devDependencies": {
-    "@types/node": "^26.0.0",
+    "@types/node": "^26.1.2",
     "@types/supertest": "^7.2.1",
     "supertest": "^7.1.4"
   }

--- a/packages/node/src/utils.ts
+++ b/packages/node/src/utils.ts
@@ -1,12 +1,28 @@
 import type Stream from 'node:stream'
 import type { NodeHttpResponse } from './types'
 
+/**
+ * Check both the response itself and its underlying stream (http2) are still writable.
+ */
 export function canWriteToNodeResponse(res: Stream.Writable | NodeHttpResponse): boolean {
-  const stream = 'stream' in res ? res.stream : res
+  if ('stream' in res && !_canWriteToStream(res.stream)) {
+    return false
+  }
+
+  return _canWriteToStream(res)
+}
+
+function _canWriteToStream(stream: Stream.Writable): boolean {
   return !stream.closed && !stream.destroyed && !stream.writableFinished && !stream.writableEnded
 }
 
+/**
+ * Get the error of the response, preferring its underlying stream's (http2).
+ */
 export function getNodeResponseError(res: Stream.Writable | NodeHttpResponse): Error | null {
-  const stream = 'stream' in res ? res.stream : res
-  return stream.errored
+  if ('stream' in res) {
+    return res.stream.errored ?? res.errored ?? null
+  }
+
+  return res.errored
 }

--- a/playgrounds/hono-node/package.json
+++ b/playgrounds/hono-node/package.json
@@ -8,10 +8,10 @@
     "type:check": "tsc --noEmit"
   },
   "devDependencies": {
-    "@hono/node-server": "^2.0.1",
+    "@hono/node-server": "^2.0.12",
     "@standardserver/core": "latest",
     "@standardserver/fetch": "latest",
-    "@types/node": "^26.0.0",
+    "@types/node": "^26.1.2",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3"
   }

--- a/playgrounds/node-http/package.json
+++ b/playgrounds/node-http/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "@standardserver/core": "latest",
     "@standardserver/node": "latest",
-    "@types/node": "^26.0.0",
+    "@types/node": "^26.1.2",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,28 @@ importers:
         specifier: ^8.21.1
         version: 8.21.1
 
+  packages/aws-lambda:
+    dependencies:
+      '@standardserver/core':
+        specifier: workspace:*
+        version: link:../core
+      '@standardserver/fetch':
+        specifier: workspace:*
+        version: link:../fetch
+      '@standardserver/node':
+        specifier: workspace:*
+        version: link:../node
+      '@standardserver/shared':
+        specifier: workspace:*
+        version: link:../shared
+    devDependencies:
+      '@types/aws-lambda':
+        specifier: ^8.10.162
+        version: 8.10.162
+      '@types/node':
+        specifier: ^26.0.0
+        version: 26.1.2
+
   packages/bun:
     devDependencies:
       '@standardserver/core':
@@ -1200,6 +1222,9 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^9.0.0 || ^10.0.0
+
+  '@types/aws-lambda@8.10.162':
+    resolution: {integrity: sha512-Fn658grtLOci1oxi1391vvDWJRKNGWRSqfxRkmN/Iy3c0tQH1USMKEXcPYHLvope+ZgTFocx9FRQJx1muBL6qw==}
 
   '@types/bun@1.3.14':
     resolution: {integrity: sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==}
@@ -4361,6 +4386,8 @@ snapshots:
       espree: 10.4.0
       estraverse: 5.3.0
       picomatch: 4.0.5
+
+  '@types/aws-lambda@8.10.162': {}
 
   '@types/bun@1.3.14':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,7 +115,7 @@ importers:
         specifier: ^8.10.162
         version: 8.10.162
       '@types/node':
-        specifier: ^26.0.0
+        specifier: ^26.1.2
         version: 26.1.2
 
   packages/bun:
@@ -179,7 +179,7 @@ importers:
         specifier: ^11.1.2
         version: 11.1.2
       '@types/node':
-        specifier: ^26.0.0
+        specifier: ^26.1.2
         version: 26.1.2
       '@types/supertest':
         specifier: ^7.2.1
@@ -213,7 +213,7 @@ importers:
         version: link:../shared
     devDependencies:
       '@types/node':
-        specifier: ^26.0.0
+        specifier: ^26.1.2
         version: 26.1.2
       '@types/supertest':
         specifier: ^7.2.1
@@ -236,7 +236,7 @@ importers:
   playgrounds/hono-node:
     devDependencies:
       '@hono/node-server':
-        specifier: ^2.0.1
+        specifier: ^2.0.12
         version: 2.0.12(hono@4.12.32)
       '@standardserver/core':
         specifier: latest
@@ -245,7 +245,7 @@ importers:
         specifier: latest
         version: link:../../packages/fetch
       '@types/node':
-        specifier: ^26.0.0
+        specifier: ^26.1.2
         version: 26.1.2
       tsx:
         specifier: ^4.22.4
@@ -263,7 +263,7 @@ importers:
         specifier: latest
         version: link:../../packages/node
       '@types/node':
-        specifier: ^26.0.0
+        specifier: ^26.1.2
         version: 26.1.2
       tsx:
         specifier: ^4.22.4


### PR DESCRIPTION
Adds `@standardserver/aws-lambda`, an adapter that converts AWS API Gateway proxy events (payload formats 1.0 and 2.0, the latter also used by Lambda Function URLs) into `StandardLazyRequest`, and writes `StandardResponse` through the stream `awslambda.streamifyResponse` provides. Streaming bodies such as server-sent events now reach clients as they are produced instead of being buffered by the function.

## Behavior

- Both payload formats are accepted through one API; format 1.0 is detected by its top-level `httpMethod` field, and events typed with `@types/aws-lambda` are accepted directly (verified by type tests).
- Status, headers, and cookies are sent via the `awslambda.HttpResponseStream` metadata prelude; multiple `set-cookie` values survive through the dedicated `cookies` field.
- Body resolution matches the fetch and node adapters (same hint → `standard-server` → `content-type` → `content-length` priority), so the same request resolves to the same `StandardBody` on every adapter.
- Format 2.0 cookies are restored into a `cookie` header, and format 1.0 query strings are re-encoded; 2.0's `rawQueryString` passes through untouched.
- Importing the package never pollutes consumer global types — the `awslambda` global is described by the exported `AwsLambdaGlobal` type and declared module-locally inside the adapter.

## Also included

- `@standardserver/node`: `canWriteToNodeResponse` and `getNodeResponseError` now check both the response and its underlying http2 stream instead of trusting only the inner stream (separate commit).

## Testing

- 60 unit tests plus compile-time type tests against `@types/aws-lambda` (dev-dependency only); package coverage is 100% on statements, branches, functions, and lines.
- Full repo suite passes (908 tests), including the existing http1/http2 tests exercising the node utils change.