### PR TITLE
fix(peer): finalize hibernation iterators instead of throwing on cleanup

### DIFF
--- a/packages/peer/src/hibernation.test.ts
+++ b/packages/peer/src/hibernation.test.ts
@@ -12,9 +12,9 @@ describe('hibernationAsyncIteratorClass', () => {
     await expect(iterator.next()).rejects.toThrow('Cannot use hibernating iterator directly')
   })
 
-  it('return() throws', async () => {
+  it('return() does not throw', async () => {
     const iterator = new HibernationAsyncIteratorClass(vi.fn())
-    await expect(iterator.return()).rejects.toThrow('Cannot use hibernating iterator directly')
+    await expect(iterator.return()).resolves.toEqual({ done: true, value: undefined })
   })
 
   it('invokes callback with correct id', () => {

--- a/packages/peer/src/hibernation.ts
+++ b/packages/peer/src/hibernation.ts
@@ -16,10 +16,8 @@ export class HibernationAsyncIteratorClass<T, TReturn = unknown, TNext = unknown
   ) {
     super(async () => {
       throw new Error('Cannot use hibernating iterator directly')
-    }, async ({ kind }) => {
-      if (kind === 'cancelled') {
-        throw new Error('Cannot use hibernating iterator directly')
-      }
+    }, async () => {
+      // nothing to clean up
     })
 
     this['~callback'] = callback

--- a/packages/peer/src/server.test.ts
+++ b/packages/peer/src/server.test.ts
@@ -324,6 +324,7 @@ describe('serverPeer', () => {
         expect(callback).toHaveBeenCalledWith('1')
         expect(send).toHaveBeenCalledTimes(1)
         expect(send).toHaveBeenNthCalledWith(1, expect.objectContaining({ kind: 'response' }))
+        await expect(hibernationIter.next()).resolves.toEqual({ done: true, value: undefined }) // already cleaned up
       })
 
       it('reject if HibernationAsyncIteratorClassCallback reject', async () => {
@@ -340,6 +341,7 @@ describe('serverPeer', () => {
         expect(send).toHaveBeenCalledTimes(2)
         expect(send).toHaveBeenNthCalledWith(1, expect.objectContaining({ kind: 'response' }))
         expect(send).toHaveBeenNthCalledWith(2, expect.objectContaining({ kind: 'cancel' }))
+        await expect(hibernationIter.next()).resolves.toEqual({ done: true, value: undefined }) // already cleaned up
       })
 
       it('cancels active transmitter on close', async () => {

--- a/packages/peer/src/server.ts
+++ b/packages/peer/src/server.ts
@@ -116,7 +116,12 @@ export class ServerPeer {
 
       if (isAsyncIteratorObject(response.body)) {
         if (response.body instanceof HibernationAsyncIteratorClass) {
-          await response.body['~callback']?.(id)
+          try {
+            await response.body['~callback']?.(id)
+          }
+          finally {
+            await response.body.return()
+          }
         }
         else {
           const transmitter = new EventStreamTransmitter(response.body, id, this.send)


### PR DESCRIPTION
Cleaning up a `HibernationAsyncIteratorClass` (via `return`, `throw`, or async dispose) no longer throws, and the server now finalizes the iterator right after the hibernation callback runs, so it always ends up properly closed.

## Fixes
- `HibernationAsyncIteratorClass` cleanup was throwing "Cannot use hibernating iterator directly" on cancellation, so any generic code path that closed the iterator would blow up. Only direct iteration via `next()` still throws.
- `ServerPeer` now calls `return()` on the iterator in a `finally` after invoking the hibernation callback, so the iterator is finalized even when the callback rejects; the rejection still propagates and cancels the request as before.

## Testing
- Server tests assert the iterator reports `{ done: true }` after handling, for both successful and rejecting callbacks.
- All peer package tests pass and typecheck is clean.