### PR TITLE
fix(shared): stop Queue.pull treating undefined as the empty sentinel

### DIFF
--- a/packages/shared/src/queue.test.ts
+++ b/packages/shared/src/queue.test.ts
@@ -12,6 +12,16 @@ describe('queue', () => {
     expect(await queue.pull()).toBe('b')
   })
 
+  it('returns buffered undefined items in order', async () => {
+    const queue = new Queue<string | undefined>()
+
+    queue.push(undefined)
+    queue.push('a')
+
+    expect(await queue.pull()).toBeUndefined()
+    expect(await queue.pull()).toBe('a')
+  })
+
   it('resolves a pending pull on push', async () => {
     const queue = new Queue<string>()
 

--- a/packages/shared/src/queue.ts
+++ b/packages/shared/src/queue.ts
@@ -30,10 +30,8 @@ export class Queue<T> {
    * @throws when the queue is closed or aborted. Note that buffered items can still be pulled after close until the buffer is drained.
    */
   async pull(): Promise<T> {
-    const item = this.items.shift()
-
-    if (item !== undefined) {
-      return item
+    if (this.items.length > 0) {
+      return this.items.shift() as T
     }
 
     if (this.closed) {


### PR DESCRIPTION
Queue.pull() shifted the buffer first and then tested the result against undefined, so a legitimately buffered undefined value was consumed and discarded while the pull parked despite later buffered items — the value was lost and pull ordering inverted. pull() now checks the buffer length before shifting, matching push(), which already hands undefined straight to a waiting resolver.

## Fixes
- `Queue<string | undefined>` (and similar) no longer loses pushed `undefined` values; pulls return them in order instead of parking.
- Latent in-repo: all current consumers use non-optional element types, but `Queue` is publicly exported with unconstrained `T`, so external consumers were exposed.

## Testing
- New regression test: `push(undefined)` then `push('a')` pulls back `undefined` then `'a'` in order.
- All 9 queue tests pass.