### PR TITLE
fix(fastify): mark fastify as optional peer dependency

### DIFF
--- a/packages/fastify/package.json
+++ b/packages/fastify/package.json
@@ -34,6 +34,11 @@
   "peerDependencies": {
     "fastify": ">=5.6.1"
   },
+  "peerDependenciesMeta": {
+    "fastify": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "@standardserver/core": "workspace:*",
     "@standardserver/node": "workspace:*"


### PR DESCRIPTION
Marks `fastify` as an optional peer dependency of `@standardserver/fastify` via `peerDependenciesMeta`. Package managers no longer warn about a missing peer or auto-install fastify for consumers who don't have it, while the `>=5.6.1` range still applies whenever fastify is present.