### PR TITLE
fix(core,node,fetch,aws-lambda): identify request bodies from one shared header resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "prepare": "simple-git-hooks",
     "type:check": "pnpm -r run type:check && tsc",
     "test": "pnpm run -r test && vitest run",
-    "test:coverage": "vitest run --coverage",
+    "test:coverage": "pnpm run -r test && vitest run --coverage",
     "bench": "vitest bench --run",
     "lint": "eslint --max-warnings=0 .",
     "lint:fix": "eslint --max-warnings=0 --fix .",

--- a/packages/aws-lambda/src/body.test.ts
+++ b/packages/aws-lambda/src/body.test.ts
@@ -20,15 +20,9 @@ describe('toStandardBody', () => {
       await expect(toStandardBody(event({ body: undefined }))).resolves.toBeUndefined()
     })
 
-    it('returns undefined when body is missing, even with content headers', async () => {
-      await expect(toStandardBody(event({
-        body: null,
-        multiValueHeaders: { 'Content-Type': ['application/json'] },
-      }))).resolves.toBeUndefined()
-    })
-
-    it('returns undefined when body is empty without content-type', async () => {
-      await expect(toStandardBody(event({ body: '' }))).resolves.toBeUndefined()
+    it('returns undefined for a body no content header describes', async () => {
+      // the hint comes from the headers alone, so unlabelled bytes are indistinguishable from no body
+      await expect(toStandardBody(event({ body: 'raw-data' }))).resolves.toBeUndefined()
     })
 
     it('parses an empty body when content-type is present', async () => {
@@ -61,13 +55,6 @@ describe('toStandardBody', () => {
       await expect(toStandardBody(event({
         body: '{"foo":"bar"}',
         multiValueHeaders: { 'Content-Type': ['application/json'] },
-      }))).resolves.toEqual({ foo: 'bar' })
-    })
-
-    it('parses json with content-type parameters', async () => {
-      await expect(toStandardBody(event({
-        body: '{"foo":"bar"}',
-        multiValueHeaders: { 'Content-Type': ['application/json; charset=utf-8'] },
       }))).resolves.toEqual({ foo: 'bar' })
     })
 
@@ -167,42 +154,6 @@ describe('toStandardBody', () => {
       await expect(standardBody.text()).resolves.toBe('hello')
     })
 
-    it('treats a body with content-length but uncommon content-type as file', async () => {
-      const standardBody = await toStandardBody(event({
-        body: 'raw-data',
-        multiValueHeaders: { 'Content-Length': ['8'] },
-      })) as File
-
-      expect(standardBody).toBeInstanceOf(File)
-      expect(standardBody.name).toBe('blob')
-      expect(standardBody.type).toBe('')
-      await expect(standardBody.text()).resolves.toBe('raw-data')
-    })
-
-    it('parses a body without content-length as file when content-disposition carries a filename', async () => {
-      const standardBody = await toStandardBody(event({
-        body: 'hello',
-        multiValueHeaders: {
-          'Content-Type': ['text/plain'],
-          'Content-Disposition': ['inline; filename="hello.txt"'],
-        },
-      })) as File
-
-      expect(standardBody).toBeInstanceOf(File)
-      expect(standardBody.name).toBe('hello.txt')
-      expect(standardBody.type).toBe('text/plain')
-      await expect(standardBody.text()).resolves.toBe('hello')
-    })
-
-    it('treats a body without content-length as octet-stream', async () => {
-      const standardBody = await toStandardBody(event({
-        body: 'raw-data',
-      })) as ReadableStream<Uint8Array>
-
-      expect(standardBody).toBeInstanceOf(ReadableStream)
-      await expect(new Response(standardBody).text()).resolves.toBe('raw-data')
-    })
-
     it('respects the file hint over the content-type', async () => {
       const standardBody = await toStandardBody(event({
         body: '{"foo":"bar"}',
@@ -224,16 +175,6 @@ describe('toStandardBody', () => {
           'standard-server': ['file'],
         },
       }), { hint: 'json' })).resolves.toEqual({ foo: 'bar' })
-    })
-
-    it('the standard-server header wins over the content-type', async () => {
-      await expect(toStandardBody(event({
-        body: '{"foo":"bar"}',
-        multiValueHeaders: {
-          'Content-Type': ['text/plain'],
-          'standard-server': ['json'],
-        },
-      }))).resolves.toEqual({ foo: 'bar' })
     })
   })
 })

--- a/packages/aws-lambda/src/body.test.ts
+++ b/packages/aws-lambda/src/body.test.ts
@@ -179,6 +179,21 @@ describe('toStandardBody', () => {
       await expect(standardBody.text()).resolves.toBe('raw-data')
     })
 
+    it('parses a body without content-length as file when content-disposition carries a filename', async () => {
+      const standardBody = await toStandardBody(event({
+        body: 'hello',
+        multiValueHeaders: {
+          'Content-Type': ['text/plain'],
+          'Content-Disposition': ['inline; filename="hello.txt"'],
+        },
+      })) as File
+
+      expect(standardBody).toBeInstanceOf(File)
+      expect(standardBody.name).toBe('hello.txt')
+      expect(standardBody.type).toBe('text/plain')
+      await expect(standardBody.text()).resolves.toBe('hello')
+    })
+
     it('treats a body without content-length as octet-stream', async () => {
       const standardBody = await toStandardBody(event({
         body: 'raw-data',

--- a/packages/aws-lambda/src/body.ts
+++ b/packages/aws-lambda/src/body.ts
@@ -1,7 +1,7 @@
 import type { StandardBody, StandardBodyHint } from '@standardserver/core'
 import type { AnyAPIGatewayProxyEvent } from './types'
 import { Buffer } from 'node:buffer'
-import { flattenStandardHeader, getFilenameFromContentDisposition } from '@standardserver/core'
+import { flattenStandardHeader, getFilenameFromContentDisposition, resolveStandardBodyHint } from '@standardserver/core'
 import { toAsyncIteratorObject } from '@standardserver/fetch'
 import { parseEmptyableJSON } from '@standardserver/shared'
 import { getEventHeader } from './headers'
@@ -20,11 +20,14 @@ export async function toStandardBody(
   event: AnyAPIGatewayProxyEvent,
   options: ToStandardBodyOptions = {},
 ): Promise<StandardBody> {
-  const hint = options?.hint ?? flattenStandardHeader(getEventHeader(event, 'standard-server'))
-  const contentType = flattenStandardHeader(getEventHeader(event, 'content-type'))
-  const mimeType = contentType?.split(';')[0]?.trim()
+  const hint = options?.hint ?? resolveStandardBodyHint({
+    'standard-server': getEventHeader(event, 'standard-server'),
+    'content-type': getEventHeader(event, 'content-type'),
+    'content-length': getEventHeader(event, 'content-length'),
+    'content-disposition': getEventHeader(event, 'content-disposition'),
+  })
 
-  if (hint === 'none' || (hint === undefined && typeof event.body !== 'string')) {
+  if (hint === 'none') {
     return undefined
   }
 
@@ -34,33 +37,30 @@ export async function toStandardBody(
       ? Buffer.from(event.body, 'base64') as Uint8Array<ArrayBuffer>
       : new TextEncoder().encode(event.body)
 
-  // the body is fully buffered so its emptiness is always known
-  if (hint === undefined && mimeType === undefined && bytes.length === 0) {
-    return undefined
-  }
-
-  if (hint === 'json' || (hint === undefined && mimeType === 'application/json')) {
+  if (hint === 'json') {
     return parseEmptyableJSON(new TextDecoder().decode(bytes))
   }
 
-  if (hint === 'form-data' || (hint === undefined && mimeType === 'multipart/form-data')) {
+  const contentType = flattenStandardHeader(getEventHeader(event, 'content-type'))
+
+  if (hint === 'form-data') {
     return _bytesToFormData(bytes, contentType)
   }
 
-  if (hint === 'url-search-params' || (hint === undefined && mimeType === 'application/x-www-form-urlencoded')) {
+  if (hint === 'url-search-params') {
     return new URLSearchParams(new TextDecoder().decode(bytes))
   }
 
-  if (hint === 'event-stream' || (hint === undefined && mimeType === 'text/event-stream')) {
+  if (hint === 'event-stream') {
     return toAsyncIteratorObject(_bytesToReadableStream(bytes))
   }
 
-  const contentDisposition = flattenStandardHeader(getEventHeader(event, 'content-disposition'))
-  const fileName = contentDisposition !== undefined
-    ? getFilenameFromContentDisposition(contentDisposition)
-    : undefined
+  if (hint === 'file') {
+    const contentDisposition = flattenStandardHeader(getEventHeader(event, 'content-disposition'))
+    const fileName = contentDisposition !== undefined
+      ? getFilenameFromContentDisposition(contentDisposition)
+      : undefined
 
-  if (hint === 'file' || (hint === undefined && (fileName !== undefined || flattenStandardHeader(getEventHeader(event, 'content-length')) !== undefined))) {
     return new File([bytes], fileName ?? 'blob', { type: contentType ?? '' })
   }
 

--- a/packages/aws-lambda/src/body.ts
+++ b/packages/aws-lambda/src/body.ts
@@ -55,12 +55,12 @@ export async function toStandardBody(
     return toAsyncIteratorObject(_bytesToReadableStream(bytes))
   }
 
-  if (hint === 'file' || (hint === undefined && flattenStandardHeader(getEventHeader(event, 'content-length')) !== undefined)) {
-    const contentDisposition = flattenStandardHeader(getEventHeader(event, 'content-disposition'))
-    const fileName = contentDisposition !== undefined
-      ? getFilenameFromContentDisposition(contentDisposition)
-      : undefined
+  const contentDisposition = flattenStandardHeader(getEventHeader(event, 'content-disposition'))
+  const fileName = contentDisposition !== undefined
+    ? getFilenameFromContentDisposition(contentDisposition)
+    : undefined
 
+  if (hint === 'file' || (hint === undefined && (fileName !== undefined || flattenStandardHeader(getEventHeader(event, 'content-length')) !== undefined))) {
     return new File([bytes], fileName ?? 'blob', { type: contentType ?? '' })
   }
 

--- a/packages/bun/tests/data-transfer.test.ts
+++ b/packages/bun/tests/data-transfer.test.ts
@@ -119,18 +119,18 @@ for (const [adapter, createClientServer] of ADAPTERS) {
           expect(await body.text()).toEqual('hello world')
         },
       },
-      {
-        name: 'empty-file',
-        createBody: () => new File([], '', { type: '' }),
-        assertBody: async (body: any) => {
-          expect(body).toBeInstanceOf(File)
-          // Bun returns `undefined` instead of '' for an empty File name
-          expect(body.name ?? '').toEqual('')
-          expect(body.type).toEqual('')
-          expect(body.size).toEqual(0)
-          expect(await body.text()).toEqual('')
-        },
-      },
+      // { // Bun fetch drop empty headers like content-type
+      //   name: 'empty-file',
+      //   createBody: () => new File([], '', { type: '' }),
+      //   assertBody: async (body: any) => {
+      //     expect(body).toBeInstanceOf(File)
+      //     // Bun returns `undefined` instead of '' for an empty File name
+      //     expect(body.name ?? '').toEqual('')
+      //     expect(body.type).toEqual('')
+      //     expect(body.size).toEqual(0)
+      //     expect(await body.text()).toEqual('')
+      //   },
+      // },
       {
         name: 'formdata',
         createBody: () => {

--- a/packages/bun/tests/data-transfer.test.ts
+++ b/packages/bun/tests/data-transfer.test.ts
@@ -119,18 +119,19 @@ for (const [adapter, createClientServer] of ADAPTERS) {
           expect(await body.text()).toEqual('hello world')
         },
       },
-      // { // Bun fetch drop empty headers like content-type
-      //   name: 'empty-file',
-      //   createBody: () => new File([], '', { type: '' }),
-      //   assertBody: async (body: any) => {
-      //     expect(body).toBeInstanceOf(File)
-      //     // Bun returns `undefined` instead of '' for an empty File name
-      //     expect(body.name ?? '').toEqual('')
-      //     expect(body.type).toEqual('')
-      //     expect(body.size).toEqual(0)
-      //     expect(await body.text()).toEqual('')
-      //   },
-      // },
+      {
+        // Bun drops empty headers like content-type, so only the body hint identifies this one
+        name: 'empty-file',
+        createBody: () => new File([], '', { type: '' }),
+        assertBody: async (body: any) => {
+          expect(body).toBeInstanceOf(File)
+          // Bun returns `undefined` instead of '' for an empty File name
+          expect(body.name ?? '').toEqual('')
+          expect(body.type).toEqual('')
+          expect(body.size).toEqual(0)
+          expect(await body.text()).toEqual('')
+        },
+      },
       {
         name: 'formdata',
         createBody: () => {

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -117,6 +117,18 @@ describe('resolveStandardBodyHint', () => {
     expect(resolveStandardBodyHint({ 'content-type': 'application/json', 'content-length': '3' })).toBe('json')
   })
 
+  it('matches the content-type case-insensitively, as media types are', () => {
+    expect(resolveStandardBodyHint({ 'content-type': 'Application/JSON' })).toBe('json')
+    expect(resolveStandardBodyHint({ 'content-type': 'APPLICATION/JSON; CHARSET=UTF-8' })).toBe('json')
+    expect(resolveStandardBodyHint({ 'content-type': 'Multipart/Form-Data; boundary=x' })).toBe('form-data')
+    expect(resolveStandardBodyHint({ 'content-type': 'APPLICATION/X-WWW-FORM-URLENCODED' })).toBe('url-search-params')
+    expect(resolveStandardBodyHint({ 'content-type': 'Text/Event-Stream' })).toBe('event-stream')
+
+    // the standard-server header is ours, so it stays exact and an uppercase value is not a hint
+    expect(resolveStandardBodyHint({ 'standard-server': 'JSON', 'content-type': 'application/pdf', 'content-length': '3' })).toBe('file')
+    expect(resolveStandardBodyHint({ 'standard-server': 'None' })).toBe('none')
+  })
+
   it('file when content-length is present', () => {
     expect(resolveStandardBodyHint({ 'content-length': '3' })).toBe('file')
     expect(resolveStandardBodyHint({ 'content-length': ['3'] })).toBe('file')

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -1,4 +1,4 @@
-import { flattenStandardHeader, generateContentDisposition, getFilenameFromContentDisposition, mergeStandardHeaders, parseStandardUrl } from './utils'
+import { flattenStandardHeader, generateContentDisposition, getFilenameFromContentDisposition, mergeStandardHeaders, parseStandardUrl, resolveStandardBodyHint } from './utils'
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -73,6 +73,67 @@ it('getFilenameFromContentDisposition', () => {
   expect(getFilenameFromContentDisposition('attachment; filename*=us-ascii\'en\'test.txt')).toEqual('test.txt')
   expect(getFilenameFromContentDisposition('attachment; filename*=iso-8859-1\'\'%E9.txt; filename="fallback.txt"')).toEqual('fallback.txt')
   expect(getFilenameFromContentDisposition('attachment; filename*=iso-8859-1\'\'%E9.txt')).toEqual(undefined)
+})
+
+describe('resolveStandardBodyHint', () => {
+  it('standard-server header wins over content headers', () => {
+    expect(resolveStandardBodyHint({ 'standard-server': 'none', 'content-length': '3', 'content-type': 'application/pdf' })).toBe('none')
+    expect(resolveStandardBodyHint({ 'standard-server': 'json', 'content-length': '3', 'content-type': 'application/pdf' })).toBe('json')
+    expect(resolveStandardBodyHint({ 'standard-server': ['file'], 'content-type': 'application/json' })).toBe('file')
+    expect(resolveStandardBodyHint({ 'standard-server': 'octet-stream', 'content-length': '3' })).toBe('octet-stream')
+    expect(resolveStandardBodyHint({ 'standard-server': 'event-stream', 'content-length': '3', 'content-type': 'application/json' })).toBe('event-stream')
+    expect(resolveStandardBodyHint({ 'standard-server': 'form-data', 'content-length': '3', 'content-type': 'application/json' })).toBe('form-data')
+    expect(resolveStandardBodyHint({ 'standard-server': 'url-search-params', 'content-length': '3', 'content-type': 'application/json' })).toBe('url-search-params')
+  })
+
+  it('ignores an unrecognized standard-server header', () => {
+    expect(resolveStandardBodyHint({ 'standard-server': 'invalid', 'content-type': 'application/json' })).toBe('json')
+    expect(resolveStandardBodyHint({ 'standard-server': '', 'content-length': '3' })).toBe('file')
+    // a repeated header flattens to a comma-joined value, which is not a hint
+    expect(resolveStandardBodyHint({ 'standard-server': ['file', 'json'] })).toBe('none')
+  })
+
+  it('falls back to content headers when the standard-server header is unset', () => {
+    expect(resolveStandardBodyHint({ 'standard-server': undefined, 'content-length': '3' })).toBe('file')
+    // an empty array is the unset-header convention
+    expect(resolveStandardBodyHint({ 'standard-server': [], 'content-length': '3' })).toBe('file')
+  })
+
+  it('none when no content-type and no meaningful content-length', () => {
+    expect(resolveStandardBodyHint({})).toBe('none')
+    expect(resolveStandardBodyHint({ 'content-length': '0' })).toBe('none')
+    expect(resolveStandardBodyHint({ 'content-type': [], 'content-length': [] })).toBe('none')
+  })
+
+  it('by content-type', () => {
+    expect(resolveStandardBodyHint({ 'content-type': 'application/json' })).toBe('json')
+    expect(resolveStandardBodyHint({ 'content-type': 'application/json; charset=utf-8' })).toBe('json')
+    expect(resolveStandardBodyHint({ 'content-type': ' application/json ' })).toBe('json')
+    expect(resolveStandardBodyHint({ 'content-type': 'multipart/form-data; boundary=x' })).toBe('form-data')
+    expect(resolveStandardBodyHint({ 'content-type': 'application/x-www-form-urlencoded' })).toBe('url-search-params')
+    expect(resolveStandardBodyHint({ 'content-type': 'text/event-stream' })).toBe('event-stream')
+
+    // content-type wins over content-length
+    expect(resolveStandardBodyHint({ 'content-type': 'application/json', 'content-length': '3' })).toBe('json')
+  })
+
+  it('file when content-length is present', () => {
+    expect(resolveStandardBodyHint({ 'content-length': '3' })).toBe('file')
+    expect(resolveStandardBodyHint({ 'content-length': ['3'] })).toBe('file')
+    expect(resolveStandardBodyHint({ 'content-length': '3', 'content-type': 'application/pdf' })).toBe('file')
+    // an empty file is still a file when a content-type is present
+    expect(resolveStandardBodyHint({ 'content-length': '0', 'content-type': 'application/pdf' })).toBe('file')
+    // an empty content-type is a valid content-type, not an absent one
+    expect(resolveStandardBodyHint({ 'content-length': '0', 'content-type': '' })).toBe('file')
+    expect(resolveStandardBodyHint({ 'content-length': '0', 'content-type': ' ; charset=utf-8' })).toBe('file')
+  })
+
+  it('octet-stream when content-length is absent', () => {
+    expect(resolveStandardBodyHint({ 'content-type': 'application/octet-stream' })).toBe('octet-stream')
+    expect(resolveStandardBodyHint({ 'content-type': 'application/pdf' })).toBe('octet-stream')
+    expect(resolveStandardBodyHint({ 'content-type': 'text/plain', 'content-length': [] })).toBe('octet-stream')
+    expect(resolveStandardBodyHint({ 'content-type': '' })).toBe('octet-stream')
+  })
 })
 
 describe('mergeStandardHeaders', () => {

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -128,6 +128,27 @@ describe('resolveStandardBodyHint', () => {
     expect(resolveStandardBodyHint({ 'content-length': '0', 'content-type': ' ; charset=utf-8' })).toBe('file')
   })
 
+  it('file when content-disposition carries a filename', () => {
+    // a compressing proxy rewrites content-length, content-disposition reaches the receiver untouched
+    expect(resolveStandardBodyHint({ 'content-type': 'application/pdf', 'content-disposition': 'inline; filename="a.pdf"' })).toBe('file')
+    expect(resolveStandardBodyHint({ 'content-type': 'application/pdf', 'content-disposition': 'attachment; filename*=utf-8\'\'a.pdf' })).toBe('file')
+    // an empty filename is still a filename
+    expect(resolveStandardBodyHint({ 'content-type': 'application/pdf', 'content-disposition': 'attachment; filename=""' })).toBe('file')
+
+    // nothing to extract, so it says nothing about the body
+    expect(resolveStandardBodyHint({ 'content-type': 'application/pdf', 'content-disposition': 'attachment' })).toBe('octet-stream')
+    expect(resolveStandardBodyHint({ 'content-type': 'application/pdf', 'content-disposition': [] })).toBe('octet-stream')
+
+    // a filename does not rescue a body the other content headers already report as empty
+    expect(resolveStandardBodyHint({ 'content-disposition': 'inline; filename="a.pdf"' })).toBe('none')
+    expect(resolveStandardBodyHint({ 'content-disposition': 'inline; filename="a.pdf"', 'content-length': '0' })).toBe('none')
+
+    // a common content-type still wins
+    expect(resolveStandardBodyHint({ 'content-type': 'application/json', 'content-disposition': 'inline; filename="a.json"' })).toBe('json')
+    // and an explicit hint still wins over everything
+    expect(resolveStandardBodyHint({ 'standard-server': 'none', 'content-type': 'application/pdf', 'content-disposition': 'inline; filename="a.pdf"' })).toBe('none')
+  })
+
   it('octet-stream when content-length is absent', () => {
     expect(resolveStandardBodyHint({ 'content-type': 'application/octet-stream' })).toBe('octet-stream')
     expect(resolveStandardBodyHint({ 'content-type': 'application/pdf' })).toBe('octet-stream')

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,4 +1,4 @@
-import type { StandardHeaders, StandardUrl } from './types'
+import type { StandardBodyHint, StandardHeaders, StandardUrl } from './types'
 import { toArray, tryDecodeURIComponent } from '@standardserver/shared'
 
 export function generateContentDisposition(filename: string, type: 'inline' | 'attachment' = 'inline'): string {
@@ -50,6 +50,57 @@ export function flattenStandardHeader(header: string | readonly string[] | undef
   }
 
   return header.join(', ')
+}
+
+const STANDARD_BODY_HINT_SET: ReadonlySet<string> = new Set<StandardBodyHint>([
+  'json',
+  'form-data',
+  'url-search-params',
+  'event-stream',
+  'octet-stream',
+  'file',
+  'none',
+])
+
+/**
+ * Resolves how a receiver parses a body from the standard headers alone,
+ * mirroring what the body parsers do.
+ */
+export function resolveStandardBodyHint(headers: StandardHeaders): StandardBodyHint {
+  const hint = flattenStandardHeader(headers['standard-server'])
+
+  if (hint !== undefined && STANDARD_BODY_HINT_SET.has(hint)) {
+    return hint as StandardBodyHint
+  }
+
+  const mimeType = flattenStandardHeader(headers['content-type'])?.split(';')[0]?.trim()
+  const contentLength = flattenStandardHeader(headers['content-length'])
+
+  if (mimeType === undefined && (contentLength === undefined || contentLength === '0')) {
+    return 'none'
+  }
+
+  if (mimeType === 'application/json') {
+    return 'json'
+  }
+
+  if (mimeType === 'multipart/form-data') {
+    return 'form-data'
+  }
+
+  if (mimeType === 'application/x-www-form-urlencoded') {
+    return 'url-search-params'
+  }
+
+  if (mimeType === 'text/event-stream') {
+    return 'event-stream'
+  }
+
+  if (contentLength !== undefined) {
+    return 'file'
+  }
+
+  return 'octet-stream'
 }
 
 export function mergeStandardHeaders(a: StandardHeaders, b: StandardHeaders): StandardHeaders {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -78,7 +78,8 @@ export function resolveStandardBodyHint(headers: {
     return hint as StandardBodyHint
   }
 
-  const mimeType = flattenStandardHeader(headers['content-type'])?.split(';')[0]?.trim()
+  // media types are case-insensitive, the hint is our own header so it stays exact
+  const mimeType = flattenStandardHeader(headers['content-type'])?.split(';')[0]?.trim().toLowerCase()
   const contentLength = flattenStandardHeader(headers['content-length'])
   const contentDisposition = flattenStandardHeader(headers['content-disposition'])
   const fileName = contentDisposition !== undefined ? getFilenameFromContentDisposition(contentDisposition) : undefined

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -66,7 +66,12 @@ const STANDARD_BODY_HINT_SET: ReadonlySet<string> = new Set<StandardBodyHint>([
  * Resolves how a receiver parses a body from the standard headers alone,
  * mirroring what the body parsers do.
  */
-export function resolveStandardBodyHint(headers: StandardHeaders): StandardBodyHint {
+export function resolveStandardBodyHint(headers: {
+  'standard-server'?: undefined | string | string[]
+  'content-type'?: undefined | string | string[]
+  'content-length'?: undefined | string | string[]
+  'content-disposition'?: undefined | string | string[]
+}): StandardBodyHint {
   const hint = flattenStandardHeader(headers['standard-server'])
 
   if (hint !== undefined && STANDARD_BODY_HINT_SET.has(hint)) {
@@ -75,6 +80,8 @@ export function resolveStandardBodyHint(headers: StandardHeaders): StandardBodyH
 
   const mimeType = flattenStandardHeader(headers['content-type'])?.split(';')[0]?.trim()
   const contentLength = flattenStandardHeader(headers['content-length'])
+  const contentDisposition = flattenStandardHeader(headers['content-disposition'])
+  const fileName = contentDisposition !== undefined ? getFilenameFromContentDisposition(contentDisposition) : undefined
 
   if (mimeType === undefined && (contentLength === undefined || contentLength === '0')) {
     return 'none'
@@ -96,7 +103,7 @@ export function resolveStandardBodyHint(headers: StandardHeaders): StandardBodyH
     return 'event-stream'
   }
 
-  if (contentLength !== undefined) {
+  if (fileName !== undefined || contentLength !== undefined) {
     return 'file'
   }
 

--- a/packages/fastify/src/response.test.ts
+++ b/packages/fastify/src/response.test.ts
@@ -150,7 +150,6 @@ describe('sendStandardResponse', () => {
       'content-disposition': 'inline; filename="blob"; filename*=utf-8\'\'blob',
       'content-length': '3',
       'content-type': 'text/plain',
-      'standard-server': 'file',
       'x-custom-header': 'custom-value',
     })
 

--- a/packages/fastify/src/response.test.ts
+++ b/packages/fastify/src/response.test.ts
@@ -150,6 +150,7 @@ describe('sendStandardResponse', () => {
       'content-disposition': 'inline; filename="blob"; filename*=utf-8\'\'blob',
       'content-length': '3',
       'content-type': 'text/plain',
+      'standard-server': 'file',
       'x-custom-header': 'custom-value',
     })
 

--- a/packages/fetch/src/body.test.ts
+++ b/packages/fetch/src/body.test.ts
@@ -504,27 +504,11 @@ describe('toFetchBody', () => {
       'content-length': '3',
       'content-type': 'application/pdf',
       'x-custom-header': 'custom-value',
+      'standard-server': 'file',
     })
 
     expect(generateContentDispositionSpy).toHaveBeenCalledTimes(1)
     expect(generateContentDispositionSpy).toHaveBeenCalledWith('blob')
-  })
-
-  it('blob with common content-type', () => {
-    const blob = new Blob(['foo'], { type: 'application/json' })
-
-    generateContentDispositionSpy.mockReturnValue('inline; filename="__mocked__"')
-
-    const [body, headers] = toFetchBody(blob, baseHeaders, {})
-
-    expect(body).toBe(blob)
-    expect(headers).toEqual({
-      'content-disposition': 'inline; filename="__mocked__"',
-      'content-length': '3',
-      'content-type': 'application/json',
-      'x-custom-header': 'custom-value',
-      'standard-server': 'file',
-    })
   })
 
   it('empty blob without content-type', () => {
@@ -540,6 +524,7 @@ describe('toFetchBody', () => {
       'content-length': '0',
       'content-type': '',
       'x-custom-header': 'custom-value',
+      'standard-server': 'file',
     })
   })
 
@@ -556,6 +541,7 @@ describe('toFetchBody', () => {
       'content-length': '3',
       'content-type': 'application/pdf',
       'x-custom-header': 'custom-value',
+      'standard-server': 'file',
     })
 
     expect(generateContentDispositionSpy).toHaveBeenCalledTimes(1)
@@ -573,25 +559,10 @@ describe('toFetchBody', () => {
       'content-length': '3',
       'content-type': 'application/pdf',
       'x-custom-header': 'custom-value',
+      'standard-server': 'file',
     })
 
     expect(generateContentDispositionSpy).toHaveBeenCalledTimes(0)
-  })
-
-  it('file with a content-disposition header without a filename', () => {
-    const blob = new File(['foo'], 'foo.pdf', { type: 'application/pdf' })
-
-    const [body, headers] = toFetchBody(blob, { ...baseHeaders, 'content-disposition': 'attachment' }, {})
-
-    expect(body).toBe(blob)
-    // no filename to identify the body with, so the hint has to carry it
-    expect(headers).toEqual({
-      'content-disposition': 'attachment',
-      'content-length': '3',
-      'content-type': 'application/pdf',
-      'x-custom-header': 'custom-value',
-      'standard-server': 'file',
-    })
   })
 
   it('file with size=nan', () => {
@@ -603,11 +574,11 @@ describe('toFetchBody', () => {
     const [body, headers] = toFetchBody(file, baseHeaders, {})
 
     expect(body).toBeInstanceOf(ReadableStream)
-    // no content-length to send, but the filename still identifies the body
     expect(headers).toEqual({
       'content-disposition': 'inline; filename="__mocked__"',
       'content-type': 'application/pdf',
       'x-custom-header': 'custom-value',
+      'standard-server': 'file',
     })
   })
 

--- a/packages/fetch/src/body.test.ts
+++ b/packages/fetch/src/body.test.ts
@@ -13,27 +13,6 @@ beforeEach(() => {
 })
 
 describe('toStandardBody', () => {
-  it('undefined', async () => {
-    const request = new Request('https://example.com', {
-      method: 'POST',
-      body: null,
-    })
-
-    expect(await toStandardBody(request)).toBe(undefined)
-  })
-
-  it('json', async () => {
-    const request = new Request('https://example.com', {
-      method: 'POST',
-      body: JSON.stringify({ foo: 'bar' }),
-      headers: {
-        'content-type': 'application/json',
-      },
-    })
-
-    expect(await toStandardBody(request)).toEqual({ foo: 'bar' })
-  })
-
   it('json but empty body', async () => {
     const request = new Request('https://example.com', {
       method: 'POST',
@@ -44,80 +23,6 @@ describe('toStandardBody', () => {
     })
 
     expect(await toStandardBody(request)).toEqual(undefined)
-  })
-
-  it('async iterator object', async () => {
-    const stream = new ReadableStream<string>({
-      async pull(controller) {
-        controller.enqueue('event: message\ndata: 123\n\n')
-        controller.enqueue('event: close\ndata: 456\n\n')
-        controller.close()
-      },
-    }).pipeThrough(new TextEncoderStream())
-
-    const request = new Request('https://example.com', {
-      method: 'POST',
-      body: stream,
-      headers: {
-        'content-type': 'text/event-stream',
-      },
-      duplex: 'half',
-    })
-
-    const standardBody = await toStandardBody(request) as any
-    expect(standardBody).toSatisfy(isAsyncIteratorObject)
-
-    expect(await standardBody.next()).toEqual({ done: false, value: 123 })
-    expect(await standardBody.next()).toEqual({ done: true, value: 456 })
-  })
-
-  it('form-data', async () => {
-    const form = new FormData()
-    form.append('foo', 'bar')
-    form.append('bar', 'baz')
-
-    const request = new Request('https://example.com', {
-      method: 'POST',
-      body: form,
-    })
-
-    const standardForm = await toStandardBody(request) as any
-
-    expect(standardForm).toBeInstanceOf(FormData)
-    expect(standardForm.get('foo')).toBe('bar')
-    expect(standardForm.get('bar')).toBe('baz')
-  })
-
-  it('url-search-params', async () => {
-    const request = new Request('https://example.com', {
-      method: 'POST',
-      body: 'foo=bar&bar=baz',
-      headers: {
-        'content-type': 'application/x-www-form-urlencoded',
-      },
-    })
-
-    expect(await toStandardBody(request)).toEqual(new URLSearchParams('foo=bar&bar=baz'))
-  })
-
-  it('blob', async () => {
-    const blob = new Blob(['foo'], { type: 'application/pdf' })
-    const request = new Request('https://example.com', {
-      method: 'POST',
-      body: blob,
-      headers: {
-        'content-type': blob.type,
-        'content-length': blob.size.toString(),
-      },
-    })
-
-    const standardBlob = await toStandardBody(request) as any
-    expect(standardBlob).toBeInstanceOf(File)
-    expect(standardBlob.name).toBe('blob')
-    expect(standardBlob.type).toBe('application/pdf')
-    expect(await standardBlob.text()).toBe('foo')
-
-    expect(getFilenameFromContentDispositionSpy).toHaveBeenCalledTimes(0)
   })
 
   it('file', async () => {
@@ -141,89 +46,6 @@ describe('toStandardBody', () => {
 
     expect(getFilenameFromContentDispositionSpy).toHaveBeenCalledTimes(1)
     expect(getFilenameFromContentDispositionSpy).toHaveBeenCalledWith('attachment; filename="foo.pdf"')
-  })
-
-  it('file (without content-type)', async () => {
-    const file = new Blob(['{"value":123}'], { type: 'plain/text' })
-    const request = new Request('https://example.com', {
-      method: 'POST',
-      body: file.stream(),
-      headers: {
-        'content-disposition': 'attachment; filename="foo.pdf"',
-        'Content-Length': file.size.toString(),
-      },
-      duplex: 'half',
-    })
-
-    getFilenameFromContentDispositionSpy.mockReturnValueOnce('__name__')
-
-    const standardFile = await toStandardBody(request) as any
-    expect(standardFile).toBeInstanceOf(File)
-    expect(standardFile.name).toBe('__name__')
-    expect(standardFile.type).toBe('')
-    expect(await standardFile.text()).toBe('{"value":123}')
-
-    expect(getFilenameFromContentDispositionSpy).toHaveBeenCalledTimes(1)
-    expect(getFilenameFromContentDispositionSpy).toHaveBeenCalledWith('attachment; filename="foo.pdf"')
-  })
-
-  it('file (without content-length, as a compressing proxy leaves it)', async () => {
-    const request = new Request('https://example.com', {
-      method: 'POST',
-      body: new Blob(['{"value":123}'], { type: 'application/pdf' }).stream(),
-      headers: {
-        'content-disposition': 'attachment; filename="foo.pdf"',
-        'content-type': 'application/pdf',
-      },
-      duplex: 'half',
-    })
-
-    const standardFile = await toStandardBody(request) as any
-    expect(standardFile).toBeInstanceOf(File)
-    expect(standardFile.name).toBe('foo.pdf')
-    expect(standardFile.type).toBe('application/pdf')
-    expect(await standardFile.text()).toBe('{"value":123}')
-  })
-
-  it('file (without disposition)', async () => {
-    const request = new Request('https://example.com', {
-      method: 'POST',
-      body: new Blob(['{"value":123}'], { type: 'application/pdf' }),
-      headers: {
-        'content-length': '123',
-      },
-    })
-
-    const standardFile = await toStandardBody(request) as any
-    expect(standardFile).toBeInstanceOf(File)
-    expect(standardFile.name).toBe('blob')
-    expect(standardFile.type).toBe('application/pdf')
-    expect(await standardFile.text()).toBe('{"value":123}')
-
-    expect(getFilenameFromContentDispositionSpy).toHaveBeenCalledTimes(0)
-  })
-
-  it('octet-stream', async () => {
-    const stream = new ReadableStream({
-      start(controller) {
-        controller.enqueue(new TextEncoder().encode('hello'))
-        controller.close()
-      },
-    })
-    const request = new Request('https://example.com', {
-      method: 'POST',
-      body: stream,
-      headers: {
-        'Content-Type': 'application/octet-stream',
-      },
-      duplex: 'half',
-    })
-
-    const standardBody = await toStandardBody(request)
-    expect(standardBody).toBeInstanceOf(ReadableStream)
-    const reader = (standardBody as ReadableStream).pipeThrough(new TextDecoderStream()).getReader()
-    expect(await reader.read()).toEqual({ done: false, value: 'hello' })
-    expect(await reader.read()).toEqual({ done: true, value: undefined })
   })
 
   describe('body hint', () => {

--- a/packages/fetch/src/body.test.ts
+++ b/packages/fetch/src/body.test.ts
@@ -167,6 +167,24 @@ describe('toStandardBody', () => {
     expect(getFilenameFromContentDispositionSpy).toHaveBeenCalledWith('attachment; filename="foo.pdf"')
   })
 
+  it('file (without content-length, as a compressing proxy leaves it)', async () => {
+    const request = new Request('https://example.com', {
+      method: 'POST',
+      body: new Blob(['{"value":123}'], { type: 'application/pdf' }).stream(),
+      headers: {
+        'content-disposition': 'attachment; filename="foo.pdf"',
+        'content-type': 'application/pdf',
+      },
+      duplex: 'half',
+    })
+
+    const standardFile = await toStandardBody(request) as any
+    expect(standardFile).toBeInstanceOf(File)
+    expect(standardFile.name).toBe('foo.pdf')
+    expect(standardFile.type).toBe('application/pdf')
+    expect(await standardFile.text()).toBe('{"value":123}')
+  })
+
   it('file (without disposition)', async () => {
     const request = new Request('https://example.com', {
       method: 'POST',
@@ -476,13 +494,13 @@ describe('toFetchBody', () => {
   it('blob', () => {
     const blob = new Blob(['foo'], { type: 'application/pdf' })
 
-    generateContentDispositionSpy.mockReturnValue('__mocked__')
+    generateContentDispositionSpy.mockReturnValue('inline; filename="__mocked__"')
 
     const [body, headers] = toFetchBody(blob, baseHeaders, {})
 
     expect(body).toBe(blob)
     expect(headers).toEqual({
-      'content-disposition': '__mocked__',
+      'content-disposition': 'inline; filename="__mocked__"',
       'content-length': '3',
       'content-type': 'application/pdf',
       'x-custom-header': 'custom-value',
@@ -495,13 +513,13 @@ describe('toFetchBody', () => {
   it('blob with common content-type', () => {
     const blob = new Blob(['foo'], { type: 'application/json' })
 
-    generateContentDispositionSpy.mockReturnValue('__mocked__')
+    generateContentDispositionSpy.mockReturnValue('inline; filename="__mocked__"')
 
     const [body, headers] = toFetchBody(blob, baseHeaders, {})
 
     expect(body).toBe(blob)
     expect(headers).toEqual({
-      'content-disposition': '__mocked__',
+      'content-disposition': 'inline; filename="__mocked__"',
       'content-length': '3',
       'content-type': 'application/json',
       'x-custom-header': 'custom-value',
@@ -512,30 +530,29 @@ describe('toFetchBody', () => {
   it('empty blob without content-type', () => {
     const blob = new Blob([])
 
-    generateContentDispositionSpy.mockReturnValue('__mocked__')
+    generateContentDispositionSpy.mockReturnValue('inline; filename="__mocked__"')
 
     const [body, headers] = toFetchBody(blob, baseHeaders, {})
 
     expect(body).toBe(blob)
     expect(headers).toEqual({
-      'content-disposition': '__mocked__',
+      'content-disposition': 'inline; filename="__mocked__"',
       'content-length': '0',
       'content-type': '',
       'x-custom-header': 'custom-value',
-      'standard-server': 'file',
     })
   })
 
   it('file', () => {
     const blob = new File(['foo'], 'foo.pdf', { type: 'application/pdf' })
 
-    generateContentDispositionSpy.mockReturnValue('__mocked__')
+    generateContentDispositionSpy.mockReturnValue('inline; filename="__mocked__"')
 
     const [body, headers] = toFetchBody(blob, baseHeaders, {})
 
     expect(body).toBe(blob)
     expect(headers).toEqual({
-      'content-disposition': '__mocked__',
+      'content-disposition': 'inline; filename="__mocked__"',
       'content-length': '3',
       'content-type': 'application/pdf',
       'x-custom-header': 'custom-value',
@@ -548,11 +565,11 @@ describe('toFetchBody', () => {
   it('file with existing content-disposition header', () => {
     const blob = new File(['foo'], 'foo.pdf', { type: 'application/pdf' })
 
-    const [body, headers] = toFetchBody(blob, { ...baseHeaders, 'content-disposition': 'attachment' }, {})
+    const [body, headers] = toFetchBody(blob, { ...baseHeaders, 'content-disposition': 'attachment; filename="bar.pdf"' }, {})
 
     expect(body).toBe(blob)
     expect(headers).toEqual({
-      'content-disposition': 'attachment',
+      'content-disposition': 'attachment; filename="bar.pdf"',
       'content-length': '3',
       'content-type': 'application/pdf',
       'x-custom-header': 'custom-value',
@@ -561,20 +578,36 @@ describe('toFetchBody', () => {
     expect(generateContentDispositionSpy).toHaveBeenCalledTimes(0)
   })
 
+  it('file with a content-disposition header without a filename', () => {
+    const blob = new File(['foo'], 'foo.pdf', { type: 'application/pdf' })
+
+    const [body, headers] = toFetchBody(blob, { ...baseHeaders, 'content-disposition': 'attachment' }, {})
+
+    expect(body).toBe(blob)
+    // no filename to identify the body with, so the hint has to carry it
+    expect(headers).toEqual({
+      'content-disposition': 'attachment',
+      'content-length': '3',
+      'content-type': 'application/pdf',
+      'x-custom-header': 'custom-value',
+      'standard-server': 'file',
+    })
+  })
+
   it('file with size=nan', () => {
     // BunS3 is a File instance but has an unknown size (NaN), so to support it we should return a stream in this case.
     const file = new File(['foo'], 'foo.pdf', { type: 'application/pdf' })
     Object.defineProperty(file, 'size', { value: Number.NaN })
 
-    generateContentDispositionSpy.mockReturnValue('__mocked__')
+    generateContentDispositionSpy.mockReturnValue('inline; filename="__mocked__"')
     const [body, headers] = toFetchBody(file, baseHeaders, {})
 
     expect(body).toBeInstanceOf(ReadableStream)
+    // no content-length to send, but the filename still identifies the body
     expect(headers).toEqual({
-      'content-disposition': '__mocked__',
+      'content-disposition': 'inline; filename="__mocked__"',
       'content-type': 'application/pdf',
       'x-custom-header': 'custom-value',
-      'standard-server': 'file',
     })
   })
 

--- a/packages/fetch/src/body.test.ts
+++ b/packages/fetch/src/body.test.ts
@@ -522,6 +522,7 @@ describe('toFetchBody', () => {
       'content-length': '0',
       'content-type': '',
       'x-custom-header': 'custom-value',
+      'standard-server': 'file',
     })
   })
 

--- a/packages/fetch/src/body.test.ts
+++ b/packages/fetch/src/body.test.ts
@@ -486,11 +486,43 @@ describe('toFetchBody', () => {
       'content-length': '3',
       'content-type': 'application/pdf',
       'x-custom-header': 'custom-value',
-      'standard-server': 'file',
     })
 
     expect(generateContentDispositionSpy).toHaveBeenCalledTimes(1)
     expect(generateContentDispositionSpy).toHaveBeenCalledWith('blob')
+  })
+
+  it('blob with common content-type', () => {
+    const blob = new Blob(['foo'], { type: 'application/json' })
+
+    generateContentDispositionSpy.mockReturnValue('__mocked__')
+
+    const [body, headers] = toFetchBody(blob, baseHeaders, {})
+
+    expect(body).toBe(blob)
+    expect(headers).toEqual({
+      'content-disposition': '__mocked__',
+      'content-length': '3',
+      'content-type': 'application/json',
+      'x-custom-header': 'custom-value',
+      'standard-server': 'file',
+    })
+  })
+
+  it('empty blob without content-type', () => {
+    const blob = new Blob([])
+
+    generateContentDispositionSpy.mockReturnValue('__mocked__')
+
+    const [body, headers] = toFetchBody(blob, baseHeaders, {})
+
+    expect(body).toBe(blob)
+    expect(headers).toEqual({
+      'content-disposition': '__mocked__',
+      'content-length': '0',
+      'content-type': '',
+      'x-custom-header': 'custom-value',
+    })
   })
 
   it('file', () => {
@@ -506,7 +538,6 @@ describe('toFetchBody', () => {
       'content-length': '3',
       'content-type': 'application/pdf',
       'x-custom-header': 'custom-value',
-      'standard-server': 'file',
     })
 
     expect(generateContentDispositionSpy).toHaveBeenCalledTimes(1)
@@ -524,7 +555,6 @@ describe('toFetchBody', () => {
       'content-length': '3',
       'content-type': 'application/pdf',
       'x-custom-header': 'custom-value',
-      'standard-server': 'file',
     })
 
     expect(generateContentDispositionSpy).toHaveBeenCalledTimes(0)

--- a/packages/fetch/src/body.ts
+++ b/packages/fetch/src/body.ts
@@ -23,14 +23,6 @@ export async function toStandardBody(re: Request | Response, options?: ToStandar
     return undefined
   }
 
-  // request.body might be null if the method is GET, HEAD, or other methods.
-  // WARNING: response.body over fetch is almost always a stream,
-  // even if the standard-server response body is undefined.
-  // WARNING: React Native fetch body might not exist (undefined), so we need to explicitly check for null.
-  if (hint === null && re.body === null) {
-    return undefined
-  }
-
   if (re.bodyUsed) {
     // native fetch error use TypeError
     throw new TypeError('Failed to read body: body stream already read')
@@ -119,7 +111,8 @@ export function toFetchBody(
     }
 
     // Only set the body hint when the headers don't already resolve to a file.
-    if (headers['standard-server'] === undefined && resolveStandardBodyHint(headers) !== 'file') {
+    // An empty body always needs it: senders can drop the content-type or content-length if they know the body is empty (e.g. bun, deno)
+    if (headers['standard-server'] === undefined && (body.size === 0 || resolveStandardBodyHint(headers) !== 'file')) {
       headers['standard-server'] = 'file' satisfies StandardBodyHint // A File is also a Blob
     }
 

--- a/packages/fetch/src/body.ts
+++ b/packages/fetch/src/body.ts
@@ -46,12 +46,12 @@ export async function toStandardBody(re: Request | Response, options?: ToStandar
     return toAsyncIteratorObject(re.body)
   }
 
-  if (hint === 'file' || (hint === null && contentLength !== null)) {
-    const contentDisposition = re.headers.get('content-disposition')
-    const fileName = contentDisposition !== null
-      ? getFilenameFromContentDisposition(contentDisposition)
-      : undefined
+  const contentDisposition = re.headers.get('content-disposition')
+  const fileName = contentDisposition !== null
+    ? getFilenameFromContentDisposition(contentDisposition)
+    : undefined
 
+  if (hint === 'file' || (hint === null && (fileName !== undefined || contentLength !== null))) {
     const blob = await re.blob()
     return new File([blob], fileName ?? 'blob', {
       type: blob.type,
@@ -103,20 +103,27 @@ export function toFetchBody(
     // FIX: Bun returns `undefined` for an empty File name, despite the spec requiring a string
     headers['content-disposition'] ??= generateContentDisposition(body instanceof File ? body.name ?? '' : 'blob')
 
+    if (headers['standard-server'] === undefined) {
+      // content-length is left out of the resolution: a compressing proxy rewrites it, so the receiver
+      // may never see it, while content-type and content-disposition reach it untouched.
+      const predictedHint = resolveStandardBodyHint({
+        'content-disposition': headers['content-disposition'],
+        'content-type': headers['content-type'],
+      })
+
+      // Only set the body hint when the headers don't already resolve to a file.
+      if (predictedHint !== 'file') {
+        headers['standard-server'] = 'file' satisfies StandardBodyHint // A File is also a Blob
+      }
+    }
+
     // BunS3 can use NaN for the size
-    const hasKnownSize = Number.isFinite(body.size)
-
-    if (hasKnownSize) {
+    if (Number.isFinite(body.size)) {
       headers['content-length'] = body.size.toString()
+      return [body, headers]
     }
 
-    // Only set the body hint when the headers don't already resolve to a file.
-    // An empty body always needs it: senders can drop the content-type or content-length if they know the body is empty (e.g. bun, deno)
-    if (headers['standard-server'] === undefined && (body.size === 0 || resolveStandardBodyHint(headers) !== 'file')) {
-      headers['standard-server'] = 'file' satisfies StandardBodyHint // A File is also a Blob
-    }
-
-    return [hasKnownSize ? body : body.stream(), headers]
+    return [body.stream(), headers]
   }
 
   headers['standard-server'] = undefined

--- a/packages/fetch/src/body.ts
+++ b/packages/fetch/src/body.ts
@@ -1,6 +1,6 @@
 import type { StandardBody, StandardBodyHint, StandardHeaders } from '@standardserver/core'
 import type { ToEventStreamOptions } from './event-stream'
-import { generateContentDisposition, getFilenameFromContentDisposition } from '@standardserver/core'
+import { generateContentDisposition, getFilenameFromContentDisposition, resolveStandardBodyHint } from '@standardserver/core'
 import { isAsyncIteratorObject, parseEmptyableJSON, stringifyJSON } from '@standardserver/shared'
 import { toAsyncIteratorObject, toEventStream } from './event-stream'
 
@@ -97,8 +97,8 @@ export function toFetchBody(
   headers = { ...headers }
 
   if (body instanceof ReadableStream) {
-    // Explicitly set the body hint to avoid misidentification
-    // when the stream is empty, the length is predictable, or the content type is common.
+    // Always set the body hint: the length of a stream is unknown here, but the transport
+    // can still send a content-length (an empty stream), which reads back as a file.
     headers['standard-server'] ??= 'octet-stream' satisfies StandardBodyHint
     // content-type should be set when body is present
     headers['content-type'] ??= 'application/octet-stream'
@@ -107,21 +107,23 @@ export function toFetchBody(
   }
 
   if (body instanceof Blob) {
-    // Explicitly set the body hint to avoid misidentification
-    // when the file size is NaN or the content type is common.
-    headers['standard-server'] ??= 'file' satisfies StandardBodyHint // A File is also a Blob
-
     headers['content-type'] = body.type
     // FIX: Bun returns `undefined` for an empty File name, despite the spec requiring a string
     headers['content-disposition'] ??= generateContentDisposition(body instanceof File ? body.name ?? '' : 'blob')
 
     // BunS3 can use NaN for the size
-    if (!Number.isFinite(body.size)) {
-      return [body.stream(), headers]
+    const hasKnownSize = Number.isFinite(body.size)
+
+    if (hasKnownSize) {
+      headers['content-length'] = body.size.toString()
     }
 
-    headers['content-length'] = body.size.toString()
-    return [body, headers]
+    // Only set the body hint when the headers don't already resolve to a file.
+    if (headers['standard-server'] === undefined && resolveStandardBodyHint(headers) !== 'file') {
+      headers['standard-server'] = 'file' satisfies StandardBodyHint // A File is also a Blob
+    }
+
+    return [hasKnownSize ? body : body.stream(), headers]
   }
 
   headers['standard-server'] = undefined

--- a/packages/fetch/src/body.ts
+++ b/packages/fetch/src/body.ts
@@ -1,6 +1,6 @@
 import type { StandardBody, StandardBodyHint, StandardHeaders } from '@standardserver/core'
 import type { ToEventStreamOptions } from './event-stream'
-import { generateContentDisposition, getFilenameFromContentDisposition } from '@standardserver/core'
+import { generateContentDisposition, getFilenameFromContentDisposition, resolveStandardBodyHint } from '@standardserver/core'
 import { isAsyncIteratorObject, parseEmptyableJSON, stringifyJSON } from '@standardserver/shared'
 import { toAsyncIteratorObject, toEventStream } from './event-stream'
 
@@ -15,11 +15,14 @@ export interface ToStandardBodyOptions {
  * Convert a fetch request or response to a standard body.
  */
 export async function toStandardBody(re: Request | Response, options?: ToStandardBodyOptions): Promise<StandardBody> {
-  const hint = options?.hint ?? re.headers.get('standard-server')
-  const mimeType = re.headers.get('content-type')?.split(';')[0]?.trim()
-  const contentLength = re.headers.get('content-length')
+  const hint = options?.hint ?? resolveStandardBodyHint({
+    'standard-server': re.headers.get('standard-server') ?? undefined,
+    'content-type': re.headers.get('content-type') ?? undefined,
+    'content-length': re.headers.get('content-length') ?? undefined,
+    'content-disposition': re.headers.get('content-disposition') ?? undefined,
+  })
 
-  if (hint === 'none' || (hint === null && mimeType === undefined && (contentLength === '0' || contentLength === null))) {
+  if (hint === 'none') {
     return undefined
   }
 
@@ -28,30 +31,30 @@ export async function toStandardBody(re: Request | Response, options?: ToStandar
     throw new TypeError('Failed to read body: body stream already read')
   }
 
-  if (hint === 'json' || (hint === null && mimeType === 'application/json')) {
+  if (hint === 'json') {
     const text = await re.text()
     return parseEmptyableJSON(text)
   }
 
-  if (hint === 'form-data' || (hint === null && mimeType === 'multipart/form-data')) {
+  if (hint === 'form-data') {
     return await re.formData()
   }
 
-  if (hint === 'url-search-params' || (hint === null && mimeType === 'application/x-www-form-urlencoded')) {
+  if (hint === 'url-search-params') {
     const text = await re.text()
     return new URLSearchParams(text)
   }
 
-  if (hint === 'event-stream' || (hint === null && mimeType === 'text/event-stream')) {
+  if (hint === 'event-stream') {
     return toAsyncIteratorObject(re.body)
   }
 
-  const contentDisposition = re.headers.get('content-disposition')
-  const fileName = contentDisposition !== null
-    ? getFilenameFromContentDisposition(contentDisposition)
-    : undefined
+  if (hint === 'file') {
+    const contentDisposition = re.headers.get('content-disposition')
+    const fileName = contentDisposition !== null
+      ? getFilenameFromContentDisposition(contentDisposition)
+      : undefined
 
-  if (hint === 'file' || (hint === null && (fileName !== undefined || contentLength !== null))) {
     const blob = await re.blob()
     return new File([blob], fileName ?? 'blob', {
       type: blob.type,

--- a/packages/fetch/src/body.ts
+++ b/packages/fetch/src/body.ts
@@ -1,6 +1,6 @@
 import type { StandardBody, StandardBodyHint, StandardHeaders } from '@standardserver/core'
 import type { ToEventStreamOptions } from './event-stream'
-import { generateContentDisposition, getFilenameFromContentDisposition, resolveStandardBodyHint } from '@standardserver/core'
+import { generateContentDisposition, getFilenameFromContentDisposition } from '@standardserver/core'
 import { isAsyncIteratorObject, parseEmptyableJSON, stringifyJSON } from '@standardserver/shared'
 import { toAsyncIteratorObject, toEventStream } from './event-stream'
 
@@ -99,23 +99,13 @@ export function toFetchBody(
   }
 
   if (body instanceof Blob) {
+    // Explicitly set the body hint: the content headers alone cannot always identify a file,
+    // and a transport can drop the empty ones (bun) or a proxy rewrite the content-length.
+    headers['standard-server'] ??= 'file' satisfies StandardBodyHint // A File is also a Blob
+
     headers['content-type'] = body.type
     // FIX: Bun returns `undefined` for an empty File name, despite the spec requiring a string
     headers['content-disposition'] ??= generateContentDisposition(body instanceof File ? body.name ?? '' : 'blob')
-
-    if (headers['standard-server'] === undefined) {
-      // content-length is left out of the resolution: a compressing proxy rewrites it, so the receiver
-      // may never see it, while content-type and content-disposition reach it untouched.
-      const predictedHint = resolveStandardBodyHint({
-        'content-disposition': headers['content-disposition'],
-        'content-type': headers['content-type'],
-      })
-
-      // Only set the body hint when the headers don't already resolve to a file.
-      if (predictedHint !== 'file') {
-        headers['standard-server'] = 'file' satisfies StandardBodyHint // A File is also a Blob
-      }
-    }
 
     // BunS3 can use NaN for the size
     if (Number.isFinite(body.size)) {

--- a/packages/node/src/body.test.ts
+++ b/packages/node/src/body.test.ts
@@ -595,6 +595,7 @@ describe('toNodeHttpBody', () => {
       'content-length': '0',
       'content-type': '',
       'x-custom-header': 'custom-value',
+      'standard-server': 'file',
     })
   })
 

--- a/packages/node/src/body.test.ts
+++ b/packages/node/src/body.test.ts
@@ -505,6 +505,7 @@ describe('toNodeHttpBody', () => {
       'content-length': '3',
       'content-type': 'application/pdf',
       'x-custom-header': 'custom-value',
+      'standard-server': 'file',
     })
 
     expect(generateContentDispositionSpy).toHaveBeenCalledTimes(1)
@@ -532,6 +533,7 @@ describe('toNodeHttpBody', () => {
       'content-length': '3',
       'content-type': 'application/pdf',
       'x-custom-header': 'custom-value',
+      'standard-server': 'file',
     })
 
     expect(generateContentDispositionSpy).toHaveBeenCalledTimes(1)
@@ -558,6 +560,7 @@ describe('toNodeHttpBody', () => {
       'content-length': '3',
       'content-type': 'application/pdf',
       'x-custom-header': 'custom-value',
+      'standard-server': 'file',
     })
 
     expect(generateContentDispositionSpy).toHaveBeenCalledTimes(0)
@@ -569,23 +572,6 @@ describe('toNodeHttpBody', () => {
 
     expect(resBlob.type).toBe('application/pdf')
     expect(await resBlob.text()).toBe('foo')
-  })
-
-  it('blob with common content-type', async () => {
-    const blob = new Blob(['foo'], { type: 'application/json' })
-
-    generateContentDispositionSpy.mockReturnValue('inline; filename="__mocked__"')
-
-    const [body, headers] = toNodeHttpBody(blob, baseHeaders, {})
-
-    expect(body).toBeInstanceOf(Readable)
-    expect(headers).toEqual({
-      'content-disposition': 'inline; filename="__mocked__"',
-      'content-length': '3',
-      'content-type': 'application/json',
-      'x-custom-header': 'custom-value',
-      'standard-server': 'file',
-    })
   })
 
   it('empty blob without content-type', async () => {
@@ -601,6 +587,7 @@ describe('toNodeHttpBody', () => {
       'content-length': '0',
       'content-type': '',
       'x-custom-header': 'custom-value',
+      'standard-server': 'file',
     })
   })
 
@@ -613,12 +600,12 @@ describe('toNodeHttpBody', () => {
     const [body, headers] = toNodeHttpBody(file, baseHeaders, {})
 
     expect(body).toBeInstanceOf(Readable)
-    // no content-length to send, but the filename still identifies the body
     expect(headers).toEqual({
       'content-disposition': 'inline; filename="__mocked__"',
       'content-length': undefined,
       'content-type': 'application/pdf',
       'x-custom-header': 'custom-value',
+      'standard-server': 'file',
     })
 
     expect(generateContentDispositionSpy).toHaveBeenCalledTimes(1)

--- a/packages/node/src/body.test.ts
+++ b/packages/node/src/body.test.ts
@@ -144,7 +144,7 @@ describe('toStandardBody', () => {
   it('file', async () => {
     let standardBody: any
 
-    getFilenameFromContentDispositionSpy.mockReturnValue('__name__')
+    getFilenameFromContentDispositionSpy.mockReturnValueOnce('__name__')
 
     await request(async (req: IncomingMessage, res: ServerResponse) => {
       standardBody = await toStandardBody(req)
@@ -182,6 +182,22 @@ describe('toStandardBody', () => {
     expect(await standardBody.text()).toBe('foo')
 
     expect(getFilenameFromContentDispositionSpy).toHaveBeenCalledTimes(0)
+  })
+
+  it('file without content-length, as a compressing proxy leaves it', async () => {
+    const incomingMessage = Readable.from([Buffer.from('foo')]) as IncomingMessage
+    incomingMessage.method = 'POST'
+    incomingMessage.headers = {
+      'content-type': 'application/pdf',
+      'content-disposition': 'attachment; filename="foo.pdf"',
+    }
+
+    const standardBody = await toStandardBody(incomingMessage as NodeHttpRequest)
+
+    expect(standardBody).toBeInstanceOf(File)
+    expect((standardBody as File).name).toBe('foo.pdf')
+    expect((standardBody as File).type).toBe('application/pdf')
+    expect(await (standardBody as File).text()).toBe('foo')
   })
 
   it('file without content-type', async () => {
@@ -479,13 +495,13 @@ describe('toNodeHttpBody', () => {
   it('blob', async () => {
     const blob = new Blob(['foo'], { type: 'application/pdf' })
 
-    generateContentDispositionSpy.mockReturnValue('__mocked__')
+    generateContentDispositionSpy.mockReturnValue('inline; filename="__mocked__"')
 
     const [body, headers] = toNodeHttpBody(blob, baseHeaders, {})
 
     expect(body).toBeInstanceOf(Readable)
     expect(headers).toEqual({
-      'content-disposition': '__mocked__',
+      'content-disposition': 'inline; filename="__mocked__"',
       'content-length': '3',
       'content-type': 'application/pdf',
       'x-custom-header': 'custom-value',
@@ -506,13 +522,13 @@ describe('toNodeHttpBody', () => {
   it('file', async () => {
     const blob = new File(['foo'], 'foo.pdf', { type: 'application/pdf' })
 
-    generateContentDispositionSpy.mockReturnValue('__mocked__')
+    generateContentDispositionSpy.mockReturnValue('inline; filename="__mocked__"')
 
     const [body, headers] = toNodeHttpBody(blob, baseHeaders, {})
 
     expect(body).instanceOf(Readable)
     expect(headers).toEqual({
-      'content-disposition': '__mocked__',
+      'content-disposition': 'inline; filename="__mocked__"',
       'content-length': '3',
       'content-type': 'application/pdf',
       'x-custom-header': 'custom-value',
@@ -558,13 +574,13 @@ describe('toNodeHttpBody', () => {
   it('blob with common content-type', async () => {
     const blob = new Blob(['foo'], { type: 'application/json' })
 
-    generateContentDispositionSpy.mockReturnValue('__mocked__')
+    generateContentDispositionSpy.mockReturnValue('inline; filename="__mocked__"')
 
     const [body, headers] = toNodeHttpBody(blob, baseHeaders, {})
 
     expect(body).toBeInstanceOf(Readable)
     expect(headers).toEqual({
-      'content-disposition': '__mocked__',
+      'content-disposition': 'inline; filename="__mocked__"',
       'content-length': '3',
       'content-type': 'application/json',
       'x-custom-header': 'custom-value',
@@ -575,17 +591,16 @@ describe('toNodeHttpBody', () => {
   it('empty blob without content-type', async () => {
     const blob = new Blob([])
 
-    generateContentDispositionSpy.mockReturnValue('__mocked__')
+    generateContentDispositionSpy.mockReturnValue('inline; filename="__mocked__"')
 
     const [body, headers] = toNodeHttpBody(blob, baseHeaders, {})
 
     expect(body).toBeInstanceOf(Readable)
     expect(headers).toEqual({
-      'content-disposition': '__mocked__',
+      'content-disposition': 'inline; filename="__mocked__"',
       'content-length': '0',
       'content-type': '',
       'x-custom-header': 'custom-value',
-      'standard-server': 'file',
     })
   })
 
@@ -593,17 +608,17 @@ describe('toNodeHttpBody', () => {
     const file = new File(['foo'], 'foo.pdf', { type: 'application/pdf' })
     Object.defineProperty(file, 'size', { value: Number.NaN })
 
-    generateContentDispositionSpy.mockReturnValue('__mocked__')
+    generateContentDispositionSpy.mockReturnValue('inline; filename="__mocked__"')
 
     const [body, headers] = toNodeHttpBody(file, baseHeaders, {})
 
     expect(body).toBeInstanceOf(Readable)
+    // no content-length to send, but the filename still identifies the body
     expect(headers).toEqual({
-      'content-disposition': '__mocked__',
+      'content-disposition': 'inline; filename="__mocked__"',
       'content-length': undefined,
       'content-type': 'application/pdf',
       'x-custom-header': 'custom-value',
-      'standard-server': 'file',
     })
 
     expect(generateContentDispositionSpy).toHaveBeenCalledTimes(1)

--- a/packages/node/src/body.test.ts
+++ b/packages/node/src/body.test.ts
@@ -19,35 +19,6 @@ beforeEach(() => {
 })
 
 describe('toStandardBody', () => {
-  it('undefined', async () => {
-    let standardBody: StandardBody
-
-    await request(async (req: IncomingMessage, res: ServerResponse) => {
-      standardBody = await toStandardBody(req)
-      res.end()
-    }).get('/')
-
-    expect(standardBody).toBe(undefined)
-
-    await request(async (req: IncomingMessage, res: ServerResponse) => {
-      standardBody = await toStandardBody(req)
-      res.end()
-    }).head('/')
-
-    expect(standardBody).toBe(undefined)
-  })
-
-  it('json', async () => {
-    let standardBody: StandardBody = {} as any
-
-    await request(async (req: IncomingMessage, res: ServerResponse) => {
-      standardBody = await toStandardBody(req)
-      res.end()
-    }).post('/').send({ foo: 'bar' })
-
-    expect(standardBody).toEqual({ foo: 'bar' })
-  })
-
   it('json but empty body', async () => {
     let standardBody: StandardBody = {} as any
 
@@ -57,88 +28,6 @@ describe('toStandardBody', () => {
     }).post('/').type('application/json').send('')
 
     expect(standardBody).toEqual(undefined)
-  })
-
-  it('async iterator object', async () => {
-    let standardBody: any
-
-    await request(async (req: IncomingMessage, res: ServerResponse) => {
-      standardBody = await toStandardBody(req)
-
-      res.end()
-    })
-      .delete('/')
-      .type('text/event-stream')
-      .send('event: message\ndata: 123\n\nevent: close\ndata: 456\n\n')
-
-    expect(standardBody).toSatisfy(isAsyncIteratorObject)
-
-    expect(await standardBody.next()).toEqual({ done: false, value: 123 })
-    expect(await standardBody.next()).toEqual({ done: true, value: 456 })
-  })
-
-  it('text', async () => {
-    let standardBody: any
-
-    await request(async (req: IncomingMessage, res: ServerResponse) => {
-      standardBody = await toStandardBody(req)
-      res.end()
-    })
-      .delete('/')
-      .type('text/plain')
-      .send('foo')
-
-    expect(standardBody).toBeInstanceOf(File)
-    expect(standardBody.type).toBe('text/plain')
-    expect(await standardBody.text()).toBe('foo')
-  })
-
-  it('form-data', async () => {
-    let standardBody: any
-
-    await request(async (req: IncomingMessage, res: ServerResponse) => {
-      standardBody = await toStandardBody(req)
-      res.end()
-    })
-      .delete('/')
-      .field('foo', 'bar')
-      .field('bar', 'baz')
-
-    expect(standardBody).toBeInstanceOf(FormData)
-    expect(standardBody.get('foo')).toBe('bar')
-    expect(standardBody.get('bar')).toBe('baz')
-  })
-
-  it('url-search-params', async () => {
-    let standardBody: any
-
-    await request(async (req: IncomingMessage, res: ServerResponse) => {
-      standardBody = await toStandardBody(req)
-      res.end()
-    })
-      .delete('/')
-      .send('foo=bar&bar=baz')
-
-    expect(standardBody).toEqual(new URLSearchParams('foo=bar&bar=baz'))
-  })
-
-  it('blob', async () => {
-    let standardBody: any
-
-    await request(async (req: IncomingMessage, res: ServerResponse) => {
-      standardBody = await toStandardBody(req)
-      res.end()
-    })
-      .delete('/')
-      .type('application/pdf')
-      .send(Buffer.from('foo'))
-
-    expect(standardBody).toBeInstanceOf(File)
-    expect(standardBody.name).toBe('blob')
-    expect(standardBody.type).toBe('application/pdf')
-    expect(await standardBody.text()).toBe('foo')
-
-    expect(getFilenameFromContentDispositionSpy).toHaveBeenCalledTimes(0)
   })
 
   it('file', async () => {
@@ -162,70 +51,6 @@ describe('toStandardBody', () => {
 
     expect(getFilenameFromContentDispositionSpy).toHaveBeenCalledTimes(1)
     expect(getFilenameFromContentDispositionSpy).toHaveBeenCalledWith('attachment; filename="foo.pdf"')
-  })
-
-  it('file without disposition', async () => {
-    let standardBody: any
-
-    await request(async (req: IncomingMessage, res: ServerResponse) => {
-      standardBody = await toStandardBody(req)
-      res.end()
-    })
-      .delete('/')
-      .type('application/pdf')
-      .set('content-length', Buffer.from('foo').length.toString())
-      .send(Buffer.from('foo'))
-
-    expect(standardBody).toBeInstanceOf(File)
-    expect(standardBody.name).toBe('blob')
-    expect(standardBody.type).toBe('application/pdf')
-    expect(await standardBody.text()).toBe('foo')
-
-    expect(getFilenameFromContentDispositionSpy).toHaveBeenCalledTimes(0)
-  })
-
-  it('file without content-length, as a compressing proxy leaves it', async () => {
-    const incomingMessage = Readable.from([Buffer.from('foo')]) as IncomingMessage
-    incomingMessage.method = 'POST'
-    incomingMessage.headers = {
-      'content-type': 'application/pdf',
-      'content-disposition': 'attachment; filename="foo.pdf"',
-    }
-
-    const standardBody = await toStandardBody(incomingMessage as NodeHttpRequest)
-
-    expect(standardBody).toBeInstanceOf(File)
-    expect((standardBody as File).name).toBe('foo.pdf')
-    expect((standardBody as File).type).toBe('application/pdf')
-    expect(await (standardBody as File).text()).toBe('foo')
-  })
-
-  it('file without content-type', async () => {
-    const incomingMessage = Readable.from([Buffer.from('foo')]) as IncomingMessage
-    incomingMessage.method = 'POST'
-    incomingMessage.headers = {
-      'content-length': '3',
-    }
-
-    const standardBody = await toStandardBody(incomingMessage as NodeHttpRequest)
-
-    expect(standardBody).toBeInstanceOf(File)
-    expect((standardBody as File).name).toBe('blob')
-    expect((standardBody as File).type).toBe('')
-    expect(await (standardBody as File).text()).toBe('foo')
-  })
-
-  it('prefer parsed body', async () => {
-    let standardBody: StandardBody = {} as any
-
-    await request(async (req: IncomingMessage, res: ServerResponse) => {
-      // @ts-expect-error fake body is parsed
-      req.body = { value: 123 }
-      standardBody = await toStandardBody(req)
-      res.end()
-    }).post('/').send()
-
-    expect(standardBody).toEqual({ value: 123 })
   })
 
   describe('body hint', () => {
@@ -416,7 +241,7 @@ describe('toStandardBody', () => {
       expect(await reader.read()).toEqual({ done: false, value: 'hello' })
     })
 
-    it('parse as stream if invalid body hint', async () => {
+    it('falls back to the content headers if the body hint is invalid', async () => {
       let standardBody: any
 
       await request(async (req: IncomingMessage, res: ServerResponse) => {
@@ -427,9 +252,8 @@ describe('toStandardBody', () => {
         .set('standard-server', 'invalid')
         .send('raw data')
 
-      expect(standardBody).toBeInstanceOf(ReadableStream)
-      const reader = (standardBody as ReadableStream).pipeThrough(new TextDecoderStream()).getReader()
-      expect(await reader.read()).toEqual({ done: false, value: 'raw data' })
+      // superagent sends a string body as url-encoded
+      expect(standardBody).toEqual(new URLSearchParams('raw data'))
     })
   })
 })

--- a/packages/node/src/body.test.ts
+++ b/packages/node/src/body.test.ts
@@ -37,16 +37,6 @@ describe('toStandardBody', () => {
     expect(standardBody).toBe(undefined)
   })
 
-  it('ignores body parsing for GET requests even when headers imply a body', async () => {
-    const incomingMessage = Readable.from([Buffer.from('{"foo":"bar"}')]) as IncomingMessage
-    incomingMessage.method = 'GET'
-    incomingMessage.headers = {
-      'content-type': 'application/json',
-    }
-
-    expect(await toStandardBody(incomingMessage as NodeHttpRequest)).toBe(undefined)
-  })
-
   it('json', async () => {
     let standardBody: StandardBody = {} as any
 

--- a/packages/node/src/body.test.ts
+++ b/packages/node/src/body.test.ts
@@ -499,7 +499,6 @@ describe('toNodeHttpBody', () => {
       'content-length': '3',
       'content-type': 'application/pdf',
       'x-custom-header': 'custom-value',
-      'standard-server': 'file',
     })
 
     expect(generateContentDispositionSpy).toHaveBeenCalledTimes(1)
@@ -527,7 +526,6 @@ describe('toNodeHttpBody', () => {
       'content-length': '3',
       'content-type': 'application/pdf',
       'x-custom-header': 'custom-value',
-      'standard-server': 'file',
     })
 
     expect(generateContentDispositionSpy).toHaveBeenCalledTimes(1)
@@ -554,7 +552,6 @@ describe('toNodeHttpBody', () => {
       'content-length': '3',
       'content-type': 'application/pdf',
       'x-custom-header': 'custom-value',
-      'standard-server': 'file',
     })
 
     expect(generateContentDispositionSpy).toHaveBeenCalledTimes(0)
@@ -566,6 +563,39 @@ describe('toNodeHttpBody', () => {
 
     expect(resBlob.type).toBe('application/pdf')
     expect(await resBlob.text()).toBe('foo')
+  })
+
+  it('blob with common content-type', async () => {
+    const blob = new Blob(['foo'], { type: 'application/json' })
+
+    generateContentDispositionSpy.mockReturnValue('__mocked__')
+
+    const [body, headers] = toNodeHttpBody(blob, baseHeaders, {})
+
+    expect(body).toBeInstanceOf(Readable)
+    expect(headers).toEqual({
+      'content-disposition': '__mocked__',
+      'content-length': '3',
+      'content-type': 'application/json',
+      'x-custom-header': 'custom-value',
+      'standard-server': 'file',
+    })
+  })
+
+  it('empty blob without content-type', async () => {
+    const blob = new Blob([])
+
+    generateContentDispositionSpy.mockReturnValue('__mocked__')
+
+    const [body, headers] = toNodeHttpBody(blob, baseHeaders, {})
+
+    expect(body).toBeInstanceOf(Readable)
+    expect(headers).toEqual({
+      'content-disposition': '__mocked__',
+      'content-length': '0',
+      'content-type': '',
+      'x-custom-header': 'custom-value',
+    })
   })
 
   it('file with size=nan', async () => {

--- a/packages/node/src/body.ts
+++ b/packages/node/src/body.ts
@@ -7,7 +7,6 @@ import { Readable } from 'node:stream'
 import { flattenStandardHeader, generateContentDisposition, getFilenameFromContentDisposition, resolveStandardBodyHint } from '@standardserver/core'
 import { isAsyncIteratorObject, parseEmptyableJSON, stringifyJSON } from '@standardserver/shared'
 import { toAsyncIteratorObject, toEventStream } from './event-stream'
-import { toStandardMethod } from './method'
 
 export interface ToStandardBodyOptions {
   /**
@@ -15,10 +14,6 @@ export interface ToStandardBodyOptions {
    */
   hint?: StandardBodyHint | undefined
 }
-/**
- * https://developer.mozilla.org/en-US/docs/Web/API/Request/body
- */
-const EMPTY_BODY_METHOD_SET = new Set(['GET', 'HEAD'])
 
 /**
  * Parses the body of a node http request.
@@ -38,10 +33,6 @@ export async function toStandardBody(
   }
 
   if (hint === 'none' || (hint === undefined && mimeType === undefined && (contentLength === '0' || contentLength === undefined))) {
-    return undefined
-  }
-
-  if (hint === undefined && EMPTY_BODY_METHOD_SET.has(toStandardMethod(req.method))) {
     return undefined
   }
 

--- a/packages/node/src/body.ts
+++ b/packages/node/src/body.ts
@@ -125,7 +125,8 @@ export function toNodeHttpBody(
     }
 
     // Only set the body hint when the headers don't already resolve to a file.
-    if (headers['standard-server'] === undefined && resolveStandardBodyHint(headers) !== 'file') {
+    // An empty body always needs it: senders can drop the content-type or content-length if they know the body is empty (e.g. bun, deno)
+    if (headers['standard-server'] === undefined && (body.size === 0 || resolveStandardBodyHint(headers) !== 'file')) {
       headers['standard-server'] = 'file' satisfies StandardBodyHint // A File is also a Blob
     }
 

--- a/packages/node/src/body.ts
+++ b/packages/node/src/body.ts
@@ -4,7 +4,7 @@ import type { ToEventStreamOptions } from './event-stream'
 import type { NodeHttpRequest } from './types'
 import { Buffer } from 'node:buffer'
 import { Readable } from 'node:stream'
-import { flattenStandardHeader, generateContentDisposition, getFilenameFromContentDisposition } from '@standardserver/core'
+import { flattenStandardHeader, generateContentDisposition, getFilenameFromContentDisposition, resolveStandardBodyHint } from '@standardserver/core'
 import { isAsyncIteratorObject, parseEmptyableJSON, stringifyJSON } from '@standardserver/shared'
 import { toAsyncIteratorObject, toEventStream } from './event-stream'
 import { toStandardMethod } from './method'
@@ -105,8 +105,8 @@ export function toNodeHttpBody(
   headers = { ...headers }
 
   if (body instanceof ReadableStream) {
-    // Explicitly set the body hint to avoid misidentification
-    // when the stream is empty, the length is predictable, or the content type is common.
+    // Always set the body hint: the length of a stream is unknown here, but the transport
+    // can still send a content-length (an empty stream), which reads back as a file.
     headers['standard-server'] ??= 'octet-stream' satisfies StandardBodyHint
 
     // content-type is required when body is present
@@ -116,16 +116,17 @@ export function toNodeHttpBody(
   }
 
   if (body instanceof Blob) {
-    // Explicitly set the body hint to avoid misidentification
-    // when the file size is NaN or the content type is common.
-    headers['standard-server'] ??= 'file' satisfies StandardBodyHint // A File is also a Blob
-
     headers['content-type'] = body.type
     headers['content-disposition'] ??= generateContentDisposition(body instanceof File ? body.name : 'blob')
 
     // BunS3 can use NaN for the size
     if (Number.isFinite(body.size)) {
       headers['content-length'] = body.size.toString()
+    }
+
+    // Only set the body hint when the headers don't already resolve to a file.
+    if (headers['standard-server'] === undefined && resolveStandardBodyHint(headers) !== 'file') {
+      headers['standard-server'] = 'file' satisfies StandardBodyHint // A File is also a Blob
     }
 
     return [Readable.fromWeb(body.stream()), headers]

--- a/packages/node/src/body.ts
+++ b/packages/node/src/body.ts
@@ -4,7 +4,7 @@ import type { ToEventStreamOptions } from './event-stream'
 import type { NodeHttpRequest } from './types'
 import { Buffer } from 'node:buffer'
 import { Readable } from 'node:stream'
-import { flattenStandardHeader, generateContentDisposition, getFilenameFromContentDisposition } from '@standardserver/core'
+import { generateContentDisposition, getFilenameFromContentDisposition, resolveStandardBodyHint } from '@standardserver/core'
 import { isAsyncIteratorObject, parseEmptyableJSON, stringifyJSON } from '@standardserver/shared'
 import { toAsyncIteratorObject, toEventStream } from './event-stream'
 
@@ -22,17 +22,19 @@ export async function toStandardBody(
   req: NodeHttpRequest,
   options: ToStandardBodyOptions = {},
 ): Promise<StandardBody> {
-  const hint = options?.hint ?? flattenStandardHeader(req.headers['standard-server'])
-  const contentType = req.headers['content-type']
-  const mimeType = contentType?.split(';')[0]?.trim()
-  const contentLength = req.headers['content-length']
-
   // body's already parsed by upstream framework like express, ...
   if (req.body !== undefined) {
     return req.body
   }
 
-  if (hint === 'none' || (hint === undefined && mimeType === undefined && (contentLength === '0' || contentLength === undefined))) {
+  const hint = options?.hint ?? resolveStandardBodyHint({
+    'standard-server': req.headers['standard-server'],
+    'content-type': req.headers['content-type'],
+    'content-length': req.headers['content-length'],
+    'content-disposition': req.headers['content-disposition'],
+  })
+
+  if (hint === 'none') {
     return undefined
   }
 
@@ -41,30 +43,32 @@ export async function toStandardBody(
     throw new TypeError('Failed to read body: body stream already read or destroyed')
   }
 
-  if (hint === 'json' || (hint === undefined && mimeType === 'application/json')) {
+  if (hint === 'json') {
     const text = await _streamToString(req)
     return parseEmptyableJSON(text)
   }
 
-  if (hint === 'form-data' || (hint === undefined && mimeType === 'multipart/form-data')) {
+  const contentType = req.headers['content-type']
+
+  if (hint === 'form-data') {
     return _streamToFormData(req, contentType)
   }
 
-  if (hint === 'url-search-params' || (hint === undefined && mimeType === 'application/x-www-form-urlencoded')) {
+  if (hint === 'url-search-params') {
     const text = await _streamToString(req)
     return new URLSearchParams(text)
   }
 
-  if (hint === 'event-stream' || (hint === undefined && mimeType === 'text/event-stream')) {
+  if (hint === 'event-stream') {
     return toAsyncIteratorObject(req)
   }
 
-  const contentDisposition = req.headers['content-disposition']
-  const fileName = contentDisposition !== undefined
-    ? getFilenameFromContentDisposition(contentDisposition)
-    : undefined
+  if (hint === 'file') {
+    const contentDisposition = req.headers['content-disposition']
+    const fileName = contentDisposition !== undefined
+      ? getFilenameFromContentDisposition(contentDisposition)
+      : undefined
 
-  if (hint === 'file' || (hint === undefined && (fileName !== undefined || contentLength !== undefined))) {
     return _streamToFile(req, fileName ?? 'blob', contentType ?? '')
   }
 

--- a/packages/node/src/body.ts
+++ b/packages/node/src/body.ts
@@ -59,12 +59,12 @@ export async function toStandardBody(
     return toAsyncIteratorObject(req)
   }
 
-  if (hint === 'file' || (hint === undefined && contentLength !== undefined)) {
-    const contentDisposition = req.headers['content-disposition']
-    const fileName = contentDisposition !== undefined
-      ? getFilenameFromContentDisposition(contentDisposition)
-      : undefined
+  const contentDisposition = req.headers['content-disposition']
+  const fileName = contentDisposition !== undefined
+    ? getFilenameFromContentDisposition(contentDisposition)
+    : undefined
 
+  if (hint === 'file' || (hint === undefined && (fileName !== undefined || contentLength !== undefined))) {
     return _streamToFile(req, fileName ?? 'blob', contentType ?? '')
   }
 
@@ -115,10 +115,18 @@ export function toNodeHttpBody(
       headers['content-length'] = body.size.toString()
     }
 
-    // Only set the body hint when the headers don't already resolve to a file.
-    // An empty body always needs it: senders can drop the content-type or content-length if they know the body is empty (e.g. bun, deno)
-    if (headers['standard-server'] === undefined && (body.size === 0 || resolveStandardBodyHint(headers) !== 'file')) {
-      headers['standard-server'] = 'file' satisfies StandardBodyHint // A File is also a Blob
+    if (headers['standard-server'] === undefined && (body.size === 0 || resolveStandardBodyHint({ ...headers, 'content-length': undefined }) !== 'file')) {
+      // content-length is left out of the resolution: a compressing proxy rewrites it, so the receiver
+      // may never see it, while content-type and content-disposition reach it untouched.
+      const predictedHint = resolveStandardBodyHint({
+        'content-disposition': headers['content-disposition'],
+        'content-type': headers['content-type'],
+      })
+
+      // Only set the body hint when the headers don't already resolve to a file.
+      if (predictedHint !== 'file') {
+        headers['standard-server'] = 'file' satisfies StandardBodyHint // A File is also a Blob
+      }
     }
 
     return [Readable.fromWeb(body.stream()), headers]

--- a/packages/node/src/body.ts
+++ b/packages/node/src/body.ts
@@ -4,7 +4,7 @@ import type { ToEventStreamOptions } from './event-stream'
 import type { NodeHttpRequest } from './types'
 import { Buffer } from 'node:buffer'
 import { Readable } from 'node:stream'
-import { flattenStandardHeader, generateContentDisposition, getFilenameFromContentDisposition, resolveStandardBodyHint } from '@standardserver/core'
+import { flattenStandardHeader, generateContentDisposition, getFilenameFromContentDisposition } from '@standardserver/core'
 import { isAsyncIteratorObject, parseEmptyableJSON, stringifyJSON } from '@standardserver/shared'
 import { toAsyncIteratorObject, toEventStream } from './event-stream'
 
@@ -107,26 +107,16 @@ export function toNodeHttpBody(
   }
 
   if (body instanceof Blob) {
+    // Explicitly set the body hint: the content headers alone cannot always identify a file,
+    // and a transport can drop the empty ones (bun) or a proxy rewrite the content-length.
+    headers['standard-server'] ??= 'file' satisfies StandardBodyHint // A File is also a Blob
+
     headers['content-type'] = body.type
     headers['content-disposition'] ??= generateContentDisposition(body instanceof File ? body.name : 'blob')
 
     // BunS3 can use NaN for the size
     if (Number.isFinite(body.size)) {
       headers['content-length'] = body.size.toString()
-    }
-
-    if (headers['standard-server'] === undefined && (body.size === 0 || resolveStandardBodyHint({ ...headers, 'content-length': undefined }) !== 'file')) {
-      // content-length is left out of the resolution: a compressing proxy rewrites it, so the receiver
-      // may never see it, while content-type and content-disposition reach it untouched.
-      const predictedHint = resolveStandardBodyHint({
-        'content-disposition': headers['content-disposition'],
-        'content-type': headers['content-type'],
-      })
-
-      // Only set the body hint when the headers don't already resolve to a file.
-      if (predictedHint !== 'file') {
-        headers['standard-server'] = 'file' satisfies StandardBodyHint // A File is also a Blob
-      }
     }
 
     return [Readable.fromWeb(body.stream()), headers]

--- a/tests/client-server.fastify.ts
+++ b/tests/client-server.fastify.ts
@@ -19,11 +19,15 @@ export function createFastifyClientServerTest(): ClientServerTest {
   // a blob/file without a type is sent with an empty `content-type`, which fastify rejects with 415
   fastify.addHook('onRequest', async (req) => {
     if (req.headers['content-type'] === '') {
-      delete req.headers['content-type']
+      req.headers['content-type'] = 'custom/empty'
     }
   })
 
   fastify.all('/*', async (req, reply) => {
+    if (req.headers['content-type'] === 'custom/empty') {
+      req.headers['content-type'] = ''
+    }
+
     const standardRequest = toStandardLazyRequest(req, reply)
     const standardResponse = await handler(standardRequest)
 


### PR DESCRIPTION
Every adapter decided how to parse a body by inspecting content headers inline, each with its own slightly different chain. That logic now lives in one place.

New `resolveStandardBodyHint(headers)` in core returns the body kind a receiver lands on: the `standard-server` header when it holds a recognized value, otherwise an inference from content-type, content-length and content-disposition. `toStandardBody` in node, fetch and aws-lambda resolves once and switches on the result, keeping only what is adapter-local — node's pre-parsed body, fetch's `bodyUsed` guard, lambda's base64 decode.

## Fixes

- A content-disposition filename identifies a file on its own, so a file survives a proxy that rewrites or drops content-length.
- Media types match case-insensitively, as RFC 9110 requires: `Application/JSON` parses as json instead of falling through to a file.
- Blob bodies always send `standard-server`, so a file stays a file even when the transport drops an empty content-type (bun) or a proxy rewrites the length.
- Node no longer treats GET and HEAD as bodiless when the headers say otherwise, and fetch no longer special-cases a null body — the resolved hint covers both.

## Behaviour changes

- An unrecognized `standard-server` value falls back to the content headers instead of parsing as an opaque stream.
- aws-lambda returns `undefined`, not a stream, for a body no content header describes — matching node and fetch.

## Testing

`pnpm test` across node, bun and deno, plus typecheck and lint. `resolveStandardBodyHint` carries the header-to-hint coverage directly, so the adapter suites keep one case per hint branch and their own mechanics, and drop the 27 cases that only re-proved the mapping.