### PR TITLE
feat(core): suggest QUERY in StandardMethod

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,4 +1,4 @@
-export type StandardMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'OPTIONS' | 'HEAD' | (string & {})
+export type StandardMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'OPTIONS' | 'HEAD' | 'QUERY' | (string & {})
 
 export type StandardUrl = `/${string}` | `/${string}?${string}` | `/${string}#${string}` | `/${string}?${string}#${string}`
 

--- a/packages/core/src/validators.test.ts
+++ b/packages/core/src/validators.test.ts
@@ -2,7 +2,7 @@ import { isStandardHeaders, isStandardMethod, isStandardRequest, isStandardRespo
 
 describe('isStandardMethod', () => {
   it('accepts standard & custom HTTP verbs', () => {
-    for (const method of ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS', 'HEAD', 'CUSTOM', 'anything']) {
+    for (const method of ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS', 'HEAD', 'QUERY', 'CUSTOM', 'anything']) {
       expect(isStandardMethod(method)).toBe(true)
     }
   })


### PR DESCRIPTION
`StandardMethod` now lists `QUERY` among its literal members, so editors suggest it alongside the other HTTP verbs instead of leaving it to be typed by hand.

Nothing about runtime behavior changes — `QUERY` was already assignable through the `(string & {})` fallback, and `isStandardMethod()` accepted it before this change.

## Notes for reviewers

`EMPTY_BODY_METHOD_SET` in `packages/node/src/body.ts` stays `['GET', 'HEAD']`: `QUERY` carries a request body by design, so it must not be treated as bodyless.

## Testing

Core package tests pass (95/95).