### PR TITLE
chore: add Open Collective funding link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -2,7 +2,7 @@
 
 github: [dinwwwh] # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
 patreon: # Replace with a single Patreon username
-open_collective: # Replace with a single Open Collective username
+open_collective: middleapi
 ko_fi: # Replace with a single Ko-fi username
 tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
 community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry

--- a/packages/aws-lambda/README.md
+++ b/packages/aws-lambda/README.md
@@ -112,7 +112,7 @@ For the project overview and the shared contract, see the [core documentation](h
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -3,6 +3,10 @@
   "type": "module",
   "version": "0.8.0",
   "license": "MIT",
+  "funding": [
+    "https://github.com/sponsors/dinwwwh",
+    "https://opencollective.com/middleapi"
+  ],
   "homepage": "https://standardserver.dev",
   "repository": {
     "type": "git",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -466,7 +466,7 @@ For transport-specific quick-starts and options, see the adapter documentation: 
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,10 @@
   "type": "module",
   "version": "0.8.0",
   "license": "MIT",
+  "funding": [
+    "https://github.com/sponsors/dinwwwh",
+    "https://opencollective.com/middleapi"
+  ],
   "homepage": "https://standardserver.dev",
   "repository": {
     "type": "git",

--- a/packages/fastify/README.md
+++ b/packages/fastify/README.md
@@ -139,7 +139,7 @@ For the project overview and the shared contract, see the [core documentation](h
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/fastify/package.json
+++ b/packages/fastify/package.json
@@ -3,6 +3,10 @@
   "type": "module",
   "version": "0.8.0",
   "license": "MIT",
+  "funding": [
+    "https://github.com/sponsors/dinwwwh",
+    "https://opencollective.com/middleapi"
+  ],
   "homepage": "https://standardserver.dev",
   "repository": {
     "type": "git",

--- a/packages/fetch/README.md
+++ b/packages/fetch/README.md
@@ -124,7 +124,7 @@ For the project overview and the shared contract this adapter implements, see th
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -3,6 +3,10 @@
   "type": "module",
   "version": "0.8.0",
   "license": "MIT",
+  "funding": [
+    "https://github.com/sponsors/dinwwwh",
+    "https://opencollective.com/middleapi"
+  ],
   "homepage": "https://standardserver.dev",
   "repository": {
     "type": "git",

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -100,7 +100,7 @@ For the project overview and the shared contract this adapter implements, see th
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -3,6 +3,10 @@
   "type": "module",
   "version": "0.8.0",
   "license": "MIT",
+  "funding": [
+    "https://github.com/sponsors/dinwwwh",
+    "https://opencollective.com/middleapi"
+  ],
   "homepage": "https://standardserver.dev",
   "repository": {
     "type": "git",

--- a/packages/peer/README.md
+++ b/packages/peer/README.md
@@ -163,7 +163,7 @@ For the project overview and the shared contract this adapter implements, see th
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/peer/package.json
+++ b/packages/peer/package.json
@@ -3,6 +3,10 @@
   "type": "module",
   "version": "0.8.0",
   "license": "MIT",
+  "funding": [
+    "https://github.com/sponsors/dinwwwh",
+    "https://opencollective.com/middleapi"
+  ],
   "homepage": "https://standardserver.dev",
   "repository": {
     "type": "git",

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -43,7 +43,7 @@ For the project overview and the public contract of the ecosystem, see the [core
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -3,6 +3,10 @@
   "type": "module",
   "version": "0.8.0",
   "license": "MIT",
+  "funding": [
+    "https://github.com/sponsors/dinwwwh",
+    "https://opencollective.com/middleapi"
+  ],
   "homepage": "https://standardserver.dev",
   "repository": {
     "type": "git",

--- a/scripts/sync-sponsors.ts
+++ b/scripts/sync-sponsors.ts
@@ -131,7 +131,7 @@ function buildSponsorsSection(sponsors: Sponsor[]): string {
   const lines = [
     '## Sponsors',
     '',
-    'Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀',
+    'Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀',
     '',
   ]
 

--- a/tests/bun/README.md
+++ b/tests/bun/README.md
@@ -2,7 +2,7 @@
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/tests/deno/README.md
+++ b/tests/deno/README.md
@@ -2,7 +2,7 @@
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>


### PR DESCRIPTION
Adds the middleapi Open Collective (https://opencollective.com/middleapi) as a funding option everywhere sponsors can find us, alongside GitHub Sponsors. Ports the funding surfaces of middleapi/orpc#1906 to this repo.

## Changes

- `.github/FUNDING.yml` now lists the `middleapi` Open Collective, so it shows up under the repository's Sponsor button.
- Every published package now has a `funding` array with both the GitHub Sponsors profile and the Open Collective link (none had a funding field before), so `npm fund` and npm package pages surface both.
- The sponsors blurb generated by `scripts/sync-sponsors.ts` links GitHub Sponsors and Open Collective; the package and test READMEs were regenerated with `pnpm sponsors:sync` and pass eslint.