### PR TITLE
chore: add description and keywords to package manifests

### DIFF
--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -2,6 +2,7 @@
   "name": "@standardserver/aws-lambda",
   "type": "module",
   "version": "0.8.0",
+  "description": "AWS Lambda adapter for Standard Server: transport-agnostic requests and responses with Lambda response streaming support",
   "license": "MIT",
   "funding": [
     "https://github.com/sponsors/dinwwwh",
@@ -13,6 +14,20 @@
     "url": "git+https://github.com/middleapi/standardserver.git",
     "directory": "packages/aws-lambda"
   },
+  "keywords": [
+    "standardserver",
+    "aws",
+    "lambda",
+    "aws-lambda",
+    "serverless",
+    "adapter",
+    "response-streaming",
+    "server",
+    "request",
+    "response",
+    "streaming",
+    "typescript"
+  ],
   "sideEffects": false,
   "publishConfig": {
     "exports": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,7 @@
   "name": "@standardserver/core",
   "type": "module",
   "version": "0.8.0",
+  "description": "The Standard Server contract: transport-agnostic request, response, body, and streaming types with body parsing rules, runtime validators, and SSE helpers shared by every adapter",
   "license": "MIT",
   "funding": [
     "https://github.com/sponsors/dinwwwh",
@@ -13,6 +14,21 @@
     "url": "git+https://github.com/middleapi/standardserver.git",
     "directory": "packages/core"
   },
+  "keywords": [
+    "standardserver",
+    "http",
+    "server",
+    "client",
+    "request",
+    "response",
+    "transport-agnostic",
+    "body-parser",
+    "validator",
+    "sse",
+    "server-sent-events",
+    "streaming",
+    "typescript"
+  ],
   "sideEffects": false,
   "publishConfig": {
     "exports": {

--- a/packages/fastify/package.json
+++ b/packages/fastify/package.json
@@ -2,6 +2,7 @@
   "name": "@standardserver/fastify",
   "type": "module",
   "version": "0.8.0",
+  "description": "Fastify adapter for Standard Server: transport-agnostic requests, responses, and streaming on top of Fastify's request and reply objects",
   "license": "MIT",
   "funding": [
     "https://github.com/sponsors/dinwwwh",
@@ -13,6 +14,18 @@
     "url": "git+https://github.com/middleapi/standardserver.git",
     "directory": "packages/fastify"
   },
+  "keywords": [
+    "standardserver",
+    "fastify",
+    "adapter",
+    "http",
+    "server",
+    "request",
+    "response",
+    "streaming",
+    "sse",
+    "typescript"
+  ],
   "sideEffects": false,
   "publishConfig": {
     "exports": {

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -2,6 +2,7 @@
   "name": "@standardserver/fetch",
   "type": "module",
   "version": "0.8.0",
+  "description": "Fetch API adapter for Standard Server: transport-agnostic requests, responses, and streaming for browsers, workers, Deno, Bun, and any Fetch-based runtime",
   "license": "MIT",
   "funding": [
     "https://github.com/sponsors/dinwwwh",
@@ -13,6 +14,22 @@
     "url": "git+https://github.com/middleapi/standardserver.git",
     "directory": "packages/fetch"
   },
+  "keywords": [
+    "standardserver",
+    "fetch",
+    "adapter",
+    "http",
+    "server",
+    "request",
+    "response",
+    "streaming",
+    "sse",
+    "browser",
+    "service-worker",
+    "deno",
+    "bun",
+    "typescript"
+  ],
   "sideEffects": false,
   "publishConfig": {
     "exports": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -2,6 +2,7 @@
   "name": "@standardserver/node",
   "type": "module",
   "version": "0.8.0",
+  "description": "Node.js HTTP and HTTP/2 adapter for Standard Server: transport-agnostic requests, responses, and streaming on top of IncomingMessage and ServerResponse",
   "license": "MIT",
   "funding": [
     "https://github.com/sponsors/dinwwwh",
@@ -13,6 +14,20 @@
     "url": "git+https://github.com/middleapi/standardserver.git",
     "directory": "packages/node"
   },
+  "keywords": [
+    "standardserver",
+    "node",
+    "nodejs",
+    "http",
+    "http2",
+    "adapter",
+    "server",
+    "request",
+    "response",
+    "streaming",
+    "sse",
+    "typescript"
+  ],
   "sideEffects": false,
   "publishConfig": {
     "exports": {

--- a/packages/peer/package.json
+++ b/packages/peer/package.json
@@ -2,6 +2,7 @@
   "name": "@standardserver/peer",
   "type": "module",
   "version": "0.8.0",
+  "description": "Message-based adapter for Standard Server: transport-agnostic requests, responses, and streaming over WebSocket, MessagePort, and custom peer transports",
   "license": "MIT",
   "funding": [
     "https://github.com/sponsors/dinwwwh",
@@ -13,6 +14,19 @@
     "url": "git+https://github.com/middleapi/standardserver.git",
     "directory": "packages/peer"
   },
+  "keywords": [
+    "standardserver",
+    "peer",
+    "websocket",
+    "messageport",
+    "message-channel",
+    "adapter",
+    "transport",
+    "request",
+    "response",
+    "streaming",
+    "typescript"
+  ],
   "sideEffects": false,
   "publishConfig": {
     "exports": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -2,6 +2,7 @@
   "name": "@standardserver/shared",
   "type": "module",
   "version": "0.8.0",
+  "description": "Internal types and utilities shared across the Standard Server ecosystem",
   "license": "MIT",
   "funding": [
     "https://github.com/sponsors/dinwwwh",
@@ -13,6 +14,13 @@
     "url": "git+https://github.com/middleapi/standardserver.git",
     "directory": "packages/shared"
   },
+  "keywords": [
+    "standardserver",
+    "utils",
+    "utilities",
+    "internal",
+    "typescript"
+  ],
   "sideEffects": false,
   "publishConfig": {
     "exports": {


### PR DESCRIPTION
Adds a `description` and `keywords` to every publishable package manifest — the two fields npm search ranks on, and both were missing across the ecosystem. The packages now surface in npm searches for their runtime or framework (fetch, node, fastify, aws-lambda, websocket) instead of only exact-name lookups.

## Notes

- Descriptions are written from each package's README, leading with searchable terms (runtime/framework name plus "Standard Server") rather than boilerplate.
- `@standardserver/shared` is described as internal with a minimal keyword set so it doesn't compete with the real entry points in search results.
- Field placement follows the oRPC manifest style: `description` after `version`, `keywords` after `repository`.
- Additions only; passes eslint, sherif, and JSON validation.