### PR TITLE
fix(core): avoid extending TransformStream in EventStreamDecoderStream

### DIFF
--- a/packages/core/src/event-stream/decoder.test.ts
+++ b/packages/core/src/event-stream/decoder.test.ts
@@ -325,6 +325,21 @@ describe('eventStreamDecoderStream', () => {
     ])
   })
 
+  it('imports without TransformStream in the global scope', async ({ onTestFinished }) => {
+    vi.stubGlobal('TransformStream', undefined)
+    vi.resetModules()
+
+    onTestFinished(() => {
+      vi.unstubAllGlobals()
+      vi.resetModules()
+    })
+
+    const module = await import('./decoder')
+
+    expect(module.EventStreamDecoderStream).toBeDefined()
+    expect(module.decodeEventStreamMessage('data: hello\n\n')).toEqual({ data: 'hello' })
+  })
+
   it('on incomplete message', async () => {
     const stream = new ReadableStream<string>({
       start(controller) {

--- a/packages/core/src/event-stream/decoder.ts
+++ b/packages/core/src/event-stream/decoder.ts
@@ -143,11 +143,14 @@ export class EventStreamDecoder {
   }
 }
 
-export class EventStreamDecoderStream extends TransformStream<string, EventStreamMessage> {
+export class EventStreamDecoderStream implements ReadableWritablePair<EventStreamMessage, string> {
+  readonly readable: ReadableStream<EventStreamMessage>
+  readonly writable: WritableStream<string>
+
   constructor() {
     let decoder!: EventStreamDecoder
 
-    super({
+    const transform = new TransformStream<string, EventStreamMessage>({
       start(controller) {
         decoder = new EventStreamDecoder((event) => {
           controller.enqueue(event)
@@ -160,5 +163,8 @@ export class EventStreamDecoderStream extends TransformStream<string, EventStrea
         decoder.end()
       },
     })
+
+    this.readable = transform.readable
+    this.writable = transform.writable
   }
 }


### PR DESCRIPTION
`EventStreamDecoderStream` no longer extends `TransformStream`. Extending resolves the global at module-evaluation time, so merely importing `@standardserver/core` crashed on runtimes that don't provide `TransformStream` — even when the stream class was never used. The class now composes a `TransformStream` created in its constructor and exposes its `readable`/`writable` pair, so the global is only needed when an instance is actually constructed.

## Fixes

- Importing `@standardserver/core` works on runtimes without a global `TransformStream`; only constructing `EventStreamDecoderStream` requires it.
- `.pipeThrough(new EventStreamDecoderStream())` behaves exactly as before — the class satisfies `ReadableWritablePair<EventStreamMessage, string>`. The only observable difference is that instances are no longer `instanceof TransformStream` (nothing in the repo relied on that).

## Testing

- New test stubs out the global `TransformStream` and asserts a fresh import of the module still succeeds; verified it fails against the previous `extends` implementation.
- Full workspace suite passes (59 files, 1075 tests) and `tsc --noEmit` is clean for `core` and `fetch`.